### PR TITLE
Add aliases before removing them. Fixes #9

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,7 @@ then
     ruby logic.rb prepare-compose-environment &&
     source scripts/prepare-docker.sh &&
     ruby logic.rb stop &&
+    source scripts/add-aliases.sh &&
     source scripts/remove-aliases.sh
 fi
 
@@ -37,6 +38,7 @@ then
     ruby logic.rb reset &&
     export COMPOSE_FILE= &&
     export COMPOSE_PROJECT_NAME= &&
+    source scripts/add-aliases.sh &&
     source scripts/remove-aliases.sh
 fi
 


### PR DESCRIPTION
Removes the possibility of an error if a new console that has not had any commands previously run is used for halt or destroy.