### PR TITLE
Increase waiting time for Postgres solves #24

### DIFF
--- a/scripts/docker/postgres/wait-for-it.sh
+++ b/scripts/docker/postgres/wait-for-it.sh
@@ -5,6 +5,6 @@ host="$1"
 # Basically wait until a psql command completes successfully (checking for the existance of a database called postgres in the output)
 until docker exec postgres bash -c 'psql -h "$host" -U "root" -lqt | cut -d \| -f 1 | grep -qw postgres' ; do
   >&2 echo "Postgres is unavailable - sleeping"
-  sleep 1
+  sleep 5
 done
 echo "Postgres is ready"


### PR DESCRIPTION
As explained in detail on issue #24 if the time in the `wait-for-it.sh` script for Postgres is increased. It allows for the database to be fully responsive before the setup queries are executed.