### PR TITLE
Replace `psql` for `pg_isready`

### DIFF
--- a/scripts/docker/postgres/wait-for-it.sh
+++ b/scripts/docker/postgres/wait-for-it.sh
@@ -3,8 +3,8 @@ set -e
 host="$1"
 
 # Basically wait until a psql command completes successfully (checking for the existance of a database called postgres in the output)
-until docker exec postgres bash -c 'psql -h "$host" -U "root" -lqt | cut -d \| -f 1 | grep -qw postgres' ; do
+until docker exec postgres bash -c 'pg_isready -h localhost' ; do
   >&2 echo "Postgres is unavailable - sleeping"
-  sleep 5
+  sleep 1
 done
 echo "Postgres is ready"

--- a/scripts/docker/postgres/wait-for-it.sh
+++ b/scripts/docker/postgres/wait-for-it.sh
@@ -5,6 +5,6 @@ host="$1"
 # Basically wait until a psql command completes successfully (checking for the existance of a database called postgres in the output)
 until docker exec postgres bash -c 'psql -h "$host" -U "root" -lqt | cut -d \| -f 1 | grep -qw postgres' ; do
   >&2 echo "Postgres is unavailable - sleeping"
-  sleep 1
+  sleep 5
 done
 echo "Postgres is ready"


### PR DESCRIPTION
As mentioned in #24 this solves the problem of the `postgres-init-fragment.sql` script not being ran due to a short sleep timer.