### PR TITLE
Export current_user env var for docker compose

### DIFF
--- a/scripts/prepare-docker.sh
+++ b/scripts/prepare-docker.sh
@@ -1,3 +1,8 @@
+# Export the current user such that it can be used inside docker compose fragments
+# When creating files inside the docker container, this prevents the files being created
+# as the root user on linux hosts
+export CURRENT_USER=$(id -u):$(id -g)
+
 # In WSL, we need to make sure our environment variables are passed to Docker for Windows' executables
 # (If symlinks to the exe's are being used rather than native client --> TCP connection)
 if grep -q Microsoft /proc/version; then


### PR DESCRIPTION
This allows us to specify that containers are run with
the current user inside docker compose fragments,
thereby preventing files created inside the container
from being created as the root user on linux hosts

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Bug fix

* **What is the current behavior?**
#37 

* **What is the new behavior (if this is a feature change)?**
Export current_user env var for use in docker compose fragments - allowing apps to specify that they should run with the current user, thereby preventing files from being created as the root user on linux hosts

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
Possibly - see https://medium.com/redbubble/running-a-docker-container-as-a-non-root-user-7d2e00f8ee15
Need to check to see whether this causes problems with our Ruby apps (Will post back once I've checked)

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [ ] Has documentation such as the [README](/README.md) been updated if necessary?
* [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
