### PR TITLE
Store host user information as env vars (Fixes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This is used by the envvironment to construct the application container and then
 * Any ports that need to be accessed from the host machine (as opposed to from other containers) should be mapped
 * A `volumes` entry should map the path of the app folder to wherever the image expects source files to be (if they are to be accessed dynamically, and not copied in at image build time)
 * If the provided log collator is to be used, then a syslog logging driver needs to be present, forwarding to logstash:25826.
+* If you wish to run the container as the host user so you have full access to any files created by the container (this is only a problem on Linux and Windows), environment variables `OUTSIDE_UID` and `OUTSIDE_GID` are provided for use in the fragment as build args (which can then be used in the `Dockerfile` to create a matching user and set them as the container-executor).
 
 Although generally an application should only have itself in it's compose fragment, there is no reason why other containers based on other Docker images cannot also be listed in this file, if they are not provided already by the dev-env.
 

--- a/scripts/prepare-docker.sh
+++ b/scripts/prepare-docker.sh
@@ -11,6 +11,11 @@ fi
 # Got to use a constant project name to ensure that containers are properly tracked regardless of how fragments are added are removed. Otherwise you get duplicate errors on the build
 export COMPOSE_PROJECT_NAME=dv
 
+# Set environment variables for compose files to send to Dockerfiles as arguments,
+# should the Dockerfile wish to create a matching user to run the container as
+export OUTSIDE_UID=$(id -u)
+export OUTSIDE_GID=$(id -g)
+
 # Load all the docker compose file references that were saved earlier
 dockerfilelist=$(<./.docker-compose-file-list)
 export COMPOSE_FILE=$dockerfilelist

--- a/scripts/prepare-docker.sh
+++ b/scripts/prepare-docker.sh
@@ -3,7 +3,7 @@
 if grep -q Microsoft /proc/version; then
   if [ -z "${WSLENV_SET+x}" ]; then
     echo -e "\e[36mWindows Subsystem for Linux detected; adding to WSLENV environment variable\e[0m"
-    export WSLENV="COMPOSE_FILE/l:COMPOSE_PROJECT_NAME${WSLENV:+:${WSLENV}}"
+    export WSLENV="OUTSIDE_UID:OUTSIDE_GID:COMPOSE_FILE/l:COMPOSE_PROJECT_NAME${WSLENV:+:${WSLENV}}"
     export WSLENV_SET=yes
   fi
 fi


### PR DESCRIPTION
* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
  Feature to help fix bug

* **What is the current behaviour?**
  There is no way to create a non-root user in an app image to run the app with that has the same uid and gid of the host user. Leaving it as root can lead to problems in certain environments - see #37 

* **What is the new behaviour (if this is a feature change)?**
  Environment variables OUTSIDE_UID and OUTSIDE_GID are exported, which can then be read in by a compose fragment and set as build args for the Dockerfile to use in useradd and groupadd commands.

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
  No

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [x] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
