### PR TITLE
Authentication services commodity

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The list of allowable commodity values is:
 11. swagger
 12. wiremock
 13. squid
+14. auth
 
 * The file may optionally also indicate that one or more services are resource intensive when starting up. The dev env will start those containers seperately - 3 at a time - and wait until each are declared healthy before starting any more. This requires a healthcheck command specified here or in the Dockerfile/docker-compose-fragment (in which case just use 'docker' in this file).
   * If one of these expensive services prefers another one to be considered "healthy" before a startup attempt is made (such as a database, to ensure immediate connectivity and no expensive restarts) then the dependent service can be specified here, with a healthcheck command following the same rules as above.
@@ -204,6 +205,53 @@ redis-cli monitor
 There are no fragments needed when using this. An HTTP proxy will be made available to all containers at runtime, at hostname `squid` and port 3128. It will be available on the host on port 30128.
 
 It also supports HTTPS, however you will need to ensure the self signed [root CA](https://github.com/LandRegistry/docker-base-images/blob/master/squid/devenv-squid-rootca.der?raw=true) is loaded into wherever it needs to go, depending on what is using the proxy (Java cacerts etc). This is best to do in your Dockerfile, alongside setting any variables needed to point to use the proxy itself.
+
+##### Auth
+
+The `auth` commodity can be used by applications requiring authentication functionality and adds two containers: `openldap` and `keycloak`.
+
+###### OpenLDAP
+
+The OpenLDAP container has been customised with a schema similar to that present in Microsoft's Active Directory and the base objects required to use it for authentication have been added. Use the following configuration to connect your application:
+
+From within a Docker container:
+
+* Host: openldap
+* Port: 389 (the default LDAP port)
+
+From the host system:
+
+* Host: localhost
+* Port: 1389
+
+Other parameters:
+
+* Base DN (AKA search base, search path, etc.): `dc=dev,dc=domain`
+* Bind DN (user account for administration): `cn=admin,dc=dev,dc=domain`
+* Admin password: `admin`
+
+**`/fragments/*.ldif`**
+
+No users are added to the LDAP database by default. To add users, groups, etc, appropriate for your application, add LDIF files to your application's fragments. Any files in the fragments directory with a `.ldif` extension will be added to the LDAP database. Entries you add must fall under the `dc=dev,dc=domain` base DN.
+
+[Example](snippets/ldap-entries.ldif)
+
+###### Keycloak
+
+Keycloak is an identity and access management system supporting the OAuth and OpenID Connect protocols. This container is built containing a `development` realm configured to use the OpenLDAP service to perform user authentication.
+
+When running, Keycloak's admin console is available at http://localhost:8180/ with username `admin` and password `admin`.
+
+Applications using OAuth flows or the OpenID Connect protocol can use Keycloak for this purpose with the following configuration parameters:
+
+* Client ID: `oauth-client`
+* Authentication URL: http://localhost:8180/auth/realms/development/protocol/openid-connect/auth  (must be resolvable by the user agent, hence we use `localhost` assuming that the user agent will be a web browser on the host system)
+* Token URL: http://keycloak:8080/auth/realms/development/protocol/openid-connect/token (use `localhost:8180` if connecting from the host system)
+* OpenID Connect configuration endpoint: http://keycloak:8080/auth/realms/development/.well-known/openid-configuration (use `localhost:8180` if connecting from the host system)
+
+JWT tokens issued from the `development` realm have been configured to mimic those issued by Microsoft ADFS servers. In particular, the LDAP `cn` field is mapped to the `UserName` claim in JWT tokens along with the `Office` claim mapped from the `physicalDeliveryOfficeName` in the LDAP database and the `group` claim listing the user's group memberships.
+
+A [JSON export](scripts/docker/auth/keycloak/development_realm.json) of the `development` realm is used to configure the realm. If further configuration of the realm is required, you can make changes in the admin console and re-export the realm using the procedure described in "Exporting a realm" [here](https://hub.docker.com/r/jboss/keycloak/#exporting-a-realm). The exported JSON can then be merged back into this repository and reused.
 
 #### Other files
 

--- a/logic.rb
+++ b/logic.rb
@@ -20,6 +20,7 @@ require_relative 'scripts/provision_postgres'
 require_relative 'scripts/provision_postgres_9.6'
 require_relative 'scripts/provision_alembic'
 require_relative 'scripts/provision_alembic_9.6'
+require_relative 'scripts/provision_auth'
 require_relative 'scripts/provision_hosts'
 require_relative 'scripts/provision_db2'
 require_relative 'scripts/provision_db2_devc'
@@ -223,6 +224,8 @@ if ['start'].include?(ARGV[0])
   provision_elasticsearch(root_loc)
   # Elasticsearch5
   provision_elasticsearch5(root_loc)
+  # Auth
+  provision_auth(root_loc)
 
   # Now that commodities are all provisioned, we can start the containers
 

--- a/scripts/docker/auth/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/auth/docker-compose-fragment.3.7.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+services:
+  openldap:
+    container_name: openldap
+    build: ../scripts/docker/auth/openldap
+    ports:
+      - "1389:389"
+
+  keycloak:
+    container_name: keycloak
+    build: ../scripts/docker/auth/keycloak
+    ports:
+      - "8180:8080"
+    depends_on:
+      - openldap

--- a/scripts/docker/auth/docker-compose-fragment.yml
+++ b/scripts/docker/auth/docker-compose-fragment.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  openldap:
+    container_name: openldap
+    build: ../scripts/docker/auth/openldap
+    ports:
+      - "1389:389"
+
+  keycloak:
+    container_name: keycloak
+    build: ../scripts/docker/auth/keycloak
+    ports:
+      - "8180:8080"
+    depends_on:
+      - openldap

--- a/scripts/docker/auth/keycloak/Dockerfile
+++ b/scripts/docker/auth/keycloak/Dockerfile
@@ -1,0 +1,8 @@
+FROM jboss/keycloak:7.0.0
+
+ADD development_realm.json /etc/keycloak/
+
+ENV KEYCLOAK_USER=admin
+ENV KEYCLOAK_PASSWORD=admin
+ENV DB_VENDOR=h2
+ENV KEYCLOAK_IMPORT=/etc/keycloak/development_realm.json

--- a/scripts/docker/auth/keycloak/development_realm.json
+++ b/scripts/docker/auth/keycloak/development_realm.json
@@ -1,0 +1,1629 @@
+{
+  "id" : "development",
+  "realm" : "development",
+  "displayName" : "Development",
+  "notBefore" : 0,
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "e6801264-738e-4ada-b44e-71770c1e8750",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "development",
+      "attributes" : { }
+    }, {
+      "id" : "7f00fa4e-c339-4bce-a914-b40ad92acdcf",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "development",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "7de7b958-f2fc-4131-ab4f-afd823f9bc93",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "0f616467-7799-40d7-a585-773272011da9",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "3b6cd137-43a9-4a63-8fbc-7b274634c630",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "67a1eca8-edb1-4d0d-a8f2-887381346873",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "manage-events", "manage-authorization", "view-clients", "query-realms", "view-events", "view-authorization", "manage-clients", "query-users", "query-clients", "manage-realm", "query-groups", "view-users", "manage-identity-providers", "impersonation", "view-realm", "create-client", "manage-users", "view-identity-providers" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "b4b7050a-8992-4f68-932c-aa5fa508d8fe",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "14ece7ff-f726-46ac-8e8d-729e63aafd4b",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "7e74bd25-71d2-4fc4-814e-d4924c86f928",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "379a7e02-dda2-44ce-86e6-be02afa06f5e",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "6fa05994-d213-4da5-8a25-571da1ccca8e",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "c69ab735-aab1-4395-beff-f30949b8e105",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "4193b0bf-dd6f-4644-9f77-4f7354cae6d3",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "a872e593-9e74-462c-a8a0-6e6387d09f4f",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "a44a81fd-d6b2-4d1f-b7b1-2d7ad88ac9fe",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "5bbf0004-95c2-48ba-bba9-97476339e5d7",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "ac260c84-fb08-4c49-9264-2e9b8d6b1ace",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "8bc19334-4b6e-4d9e-96ae-a2192715c40d",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "29127d87-dc05-4b72-b668-39b80126b673",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "7079ef4f-f6f8-493d-870d-651576a83ef0",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      }, {
+        "id" : "8f085833-e2b9-44ff-8db4-be66970d84c4",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+        "attributes" : { }
+      } ],
+      "oauth-client" : [ ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "broker" : [ {
+        "id" : "fc9c493c-cdaf-4f09-a933-4e0421204554",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "104ebddb-14ab-4ac7-9ae5-d0febb5dce41",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "b3354017-f195-4b6d-a4f4-1350add1512a",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "ff0abbdb-0343-4e96-8e0d-d4e9590e8060",
+        "attributes" : { }
+      }, {
+        "id" : "ac14897c-14ec-4645-8f47-b70d1b805b28",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ff0abbdb-0343-4e96-8e0d-d4e9590e8060",
+        "attributes" : { }
+      }, {
+        "id" : "c6e2576f-4c1f-409f-8d12-974c75fec41b",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ff0abbdb-0343-4e96-8e0d-d4e9590e8060",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRoles" : [ "offline_access", "uma_authorization" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clients" : [ {
+    "id" : "ff0abbdb-0343-4e96-8e0d-d4e9590e8060",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "baseUrl" : "/auth/realms/development/account",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "5c88eef4-59af-4be6-b4ba-bf035893e66a",
+    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "redirectUris" : [ "/auth/realms/development/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "00982eb6-24e3-4c35-98e9-a85804792de0",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "1b2dc674-7cb9-4de0-bf7b-8a0d1b3f20c8",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "104ebddb-14ab-4ac7-9ae5-d0febb5dce41",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "72123523-e1f4-4e3d-8d0d-9c8d7ea9a000",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "709e879d-65f7-4698-9924-a148c1ecda00",
+    "clientId" : "oauth-client",
+    "name" : "OAuth Client",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "cb1dd2d0-50cc-452c-bf68-207a0d482ef8",
+    "redirectUris" : [ "*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "exclude.session.state.from.auth.response" : "false",
+      "saml_force_name_id_format" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "212ee739-8709-403a-8cea-154355bfd7b4",
+      "name" : "group",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-group-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "full.path" : "false",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "group",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "e7970e4f-cea3-477b-b0f8-b676b507a20f",
+      "name" : "UserName",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "UserName",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a9594413-5648-4ff6-8c46-fb95dd7fd019",
+      "name" : "Office",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "office",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "Office",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "c6964924-43a0-4dbf-ad33-8d41593c8e8f",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "4d0de2fe-c3d8-479b-bca6-24f215dc23e8",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "8b2fe371-777e-4431-9355-5a6a12a1226d",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "baseUrl" : "/auth/admin/development/console/index.html",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "95313c71-5c29-4843-b3cb-f32176cdc857",
+    "redirectUris" : [ "/auth/admin/development/console/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "709c0515-db7f-4209-b506-af2d6438ce93",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "role_list", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "953cdb2e-af7c-4e7d-a59a-ad0889253694",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "041a1d48-b676-43f7-bf7a-922837c6f490",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "3b1cc2c9-f7b3-446e-959d-df3397d96036",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "083e30f7-b4c4-45f7-898b-04e8d0e14e43",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fcd48866-1afb-4e94-9be1-07b810e2a502",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "d74a9149-f036-468f-8831-d0304e856698",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "45531b25-3744-4ace-852e-a222a3e83ce7",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b4828382-a0de-4052-8266-17094037741d",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "3df91b8a-453b-4485-881e-162ab8a96574",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "82ab5a92-f588-4baa-894b-8715af92f206",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "33a9e7ca-4772-4fdc-9c80-2caf436bafa2",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "5e54c8fe-1e0e-4214-84f8-21e3ab3e96b2",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "4f51ed0a-4416-4274-861e-588134304a28",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "6e195740-474a-4f63-8b57-25584e605f10",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bbbe66e7-737a-4ea1-a0f5-98c882fb25a0",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "03e4efd8-baf4-4f95-82c7-eeb37c699da4",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8fa35a5d-aa28-4806-8507-9bfcf3336989",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9a09daf0-d3cb-4fab-8bd9-1b656322c3bd",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0ca648c8-b0a4-4eb0-befb-6af8644f5b41",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "daaa5079-c220-49a3-be05-343e728212f4",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0ee07516-21da-4986-8199-05efd5bf651b",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e8dbb671-3a50-4233-b1d8-139c322d35ff",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0dd3ef2f-667d-42b2-8147-40ba74ea0ddd",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "87bf8e0a-3c1d-4a88-9606-db43c8be049a",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "819310c3-88d1-4c55-a4b6-63051a943748",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "209149e0-4141-4f3c-a767-89365f26ca99",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ded1d526-4fd6-43e4-a745-c7214ecf935f",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "99ba381c-3615-450c-8f91-eb7ccb4707be",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "3fda346e-dd7d-46f5-90a0-3d5ad808c237",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "4225341c-61b4-493b-a1f5-0db6ab73453d",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "92305d21-144e-44e7-9727-ac2dcd1e7f72",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "a34e49f9-5df7-40d7-b6d5-2647c30b65e0",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "f31b9c10-da53-4990-ada9-90790f9e1c7a",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "3c4821cf-d38e-4fd9-b1cc-405b32667b26",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "fcec4a21-ccdf-41e5-98c0-bb41e39e3a00",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "email", "web-origins", "roles", "profile", "role_list" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "phone", "address", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "xXSSProtection" : "1; mode=block",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "44044ce1-3133-49a1-b2f1-6ae9311413f9",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "0002d49c-bfeb-4a14-803b-20211bb9f899",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "68ecd214-6638-4ae3-bc61-2f746487e7c5",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "4f17f6bd-6510-412b-be06-dfed8ea759b6",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "86246d36-3f0d-45e5-92a6-5127b7a8f905",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "9a47bcf4-e3a1-4dc4-bf4c-f0c05026c487",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-role-list-mapper" ]
+      }
+    }, {
+      "id" : "6922b7fd-a5bc-48fd-99c6-ee24c03c27a5",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-address-mapper" ]
+      }
+    }, {
+      "id" : "ed23f61f-9477-49e0-964f-9c42473e45a7",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.storage.UserStorageProvider" : [ {
+      "id" : "45925eaf-887f-4c9b-a2e3-dd8bc69c15f8",
+      "name" : "ldap",
+      "providerId" : "ldap",
+      "subComponents" : {
+        "org.keycloak.storage.ldap.mappers.LDAPStorageMapper" : [ {
+          "id" : "b3b3347c-934a-4e78-b3cc-1953b6a69e17",
+          "name" : "modify date",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "modifyTimestamp" ],
+            "is.mandatory.in.ldap" : [ "false" ],
+            "read.only" : [ "true" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "user.model.attribute" : [ "modifyTimestamp" ]
+          }
+        }, {
+          "id" : "bd680cc9-72f7-4c08-aab1-acf70e520ae3",
+          "name" : "username",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "cn" ],
+            "is.mandatory.in.ldap" : [ "true" ],
+            "read.only" : [ "false" ],
+            "always.read.value.from.ldap" : [ "false" ],
+            "user.model.attribute" : [ "username" ]
+          }
+        }, {
+          "id" : "4cacaf51-12ab-4fe6-aed1-77291ff60992",
+          "name" : "email",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "mail" ],
+            "is.mandatory.in.ldap" : [ "false" ],
+            "always.read.value.from.ldap" : [ "false" ],
+            "read.only" : [ "false" ],
+            "user.model.attribute" : [ "email" ]
+          }
+        }, {
+          "id" : "3855ff88-30ec-4182-a65e-d5e551fb861d",
+          "name" : "first name",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "givenName" ],
+            "is.mandatory.in.ldap" : [ "true" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "read.only" : [ "false" ],
+            "user.model.attribute" : [ "firstName" ]
+          }
+        }, {
+          "id" : "6aa3bb11-6da4-4516-9f7c-704d0377ad9a",
+          "name" : "last name",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "sn" ],
+            "is.mandatory.in.ldap" : [ "true" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "read.only" : [ "false" ],
+            "user.model.attribute" : [ "lastName" ]
+          }
+        }, {
+          "id" : "da9ae36d-6e62-4f18-87b0-79333c38e113",
+          "name" : "office",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "physicalDeliveryOfficeName" ],
+            "is.mandatory.in.ldap" : [ "false" ],
+            "is.binary.attribute" : [ "false" ],
+            "read.only" : [ "false" ],
+            "always.read.value.from.ldap" : [ "false" ],
+            "user.model.attribute" : [ "office" ]
+          }
+        }, {
+          "id" : "b4a392fa-445c-455e-91c6-571d8df900ca",
+          "name" : "creation date",
+          "providerId" : "user-attribute-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "ldap.attribute" : [ "createTimestamp" ],
+            "is.mandatory.in.ldap" : [ "false" ],
+            "read.only" : [ "true" ],
+            "always.read.value.from.ldap" : [ "true" ],
+            "user.model.attribute" : [ "createTimestamp" ]
+          }
+        }, {
+          "id" : "72857980-015d-4a45-862f-037bf2af712d",
+          "name" : "group",
+          "providerId" : "group-ldap-mapper",
+          "subComponents" : { },
+          "config" : {
+            "mode" : [ "LDAP_ONLY" ],
+            "membership.attribute.type" : [ "DN" ],
+            "user.roles.retrieve.strategy" : [ "LOAD_GROUPS_BY_MEMBER_ATTRIBUTE" ],
+            "group.name.ldap.attribute" : [ "entryDN" ],
+            "membership.ldap.attribute" : [ "member" ],
+            "ignore.missing.groups" : [ "false" ],
+            "membership.user.ldap.attribute" : [ "cn" ],
+            "preserve.group.inheritance" : [ "false" ],
+            "group.object.classes" : [ "groupOfNames" ],
+            "groups.dn" : [ "dc=dev,dc=domain" ],
+            "memberof.ldap.attribute" : [ "memberOf" ],
+            "drop.non.existing.groups.during.sync" : [ "false" ]
+          }
+        } ]
+      },
+      "config" : {
+        "pagination" : [ "true" ],
+        "fullSyncPeriod" : [ "-1" ],
+        "usersDn" : [ "dc=dev,dc=domain" ],
+        "connectionPooling" : [ "true" ],
+        "cachePolicy" : [ "DEFAULT" ],
+        "useKerberosForPasswordAuthentication" : [ "false" ],
+        "importEnabled" : [ "true" ],
+        "enabled" : [ "true" ],
+        "usernameLDAPAttribute" : [ "cn" ],
+        "changedSyncPeriod" : [ "-1" ],
+        "bindCredential" : [ "admin" ],
+        "bindDn" : [ "cn=admin,dc=dev,dc=domain" ],
+        "vendor" : [ "other" ],
+        "uuidLDAPAttribute" : [ "entryDN" ],
+        "allowKerberosAuthentication" : [ "false" ],
+        "connectionUrl" : [ "ldap://openldap" ],
+        "syncRegistrations" : [ "false" ],
+        "authType" : [ "simple" ],
+        "debug" : [ "false" ],
+        "searchScope" : [ "1" ],
+        "useTruststoreSpi" : [ "ldapsOnly" ],
+        "priority" : [ "0" ],
+        "userObjectClasses" : [ "inetOrgPerson, organizationalPerson" ],
+        "rdnLDAPAttribute" : [ "cn" ],
+        "editMode" : [ "WRITABLE" ],
+        "validatePasswordPolicy" : [ "false" ],
+        "batchSizeForSync" : [ "1000" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "2c7e70ea-7e84-432a-a06c-f259e25569e4",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAuUFncyCZ4pszQ0qH0oX1qTKPP6TekWZR//qX/i+VLVTeKBP5BnSPdq11c9zrQifPJ6thtfhd9Qta7tCd1J0BuSriSdqTC5GIQgV0q8RwBFQNPuqM5847quHyQ6yeT/ZTlymu+Y8uSQvq5I5fG4vfJCnLkvhl4ZSNp0pRxW6O46CGY35mQeezLjt6ntL/zTUG3mbnzG08zt+18JBTNre/y+sxwd4s59LyqD6x98yJA2kcQPx8i9WoiPzXPBDoO8OAM2aWGAPahMe3Fy3sHaRiYIn3Pt7NoeC/60SU1eCSQxfAd7ofzZbNTeTfg38PPwMmRIUvfpr17oQ0oLB9r8NMoQIDAQABAoIBACLflgrNG0rWLns/X3wY7ZrRQrgXYDJ80Xjfgpc9+9YRwNRIljtJ2+vaUV7jOoI0nkF4eKdZvs4vOgn0yZFJkRZ7ZSfD9qRZ3A2Zm1HuY6vc6rVqT+YfI4pSiFmG+DJTS38MQL0H4A2uKaSmzG6SEQpst77N9dfWMChKzEPfQRTGQ+64ZJXvXG32dL2so1dZmYGDZHWqJj5xq9bm+W7FzJQ5PkutSWv8fWDyhNS7PsbglEAKhNBfQ45GhzDrnwXu5Z7MPPSGWNd50lA6D8kXqVGmLNWKKn0JTltFSeflji/6UaYQHxeIZJj9MCcoOHnOGRhhBfzXTejfB+lvYgo+0sECgYEA6om4gC4G7h6gFUaPa2pJcGbLWFiuuUV0agsbqj5tYO/rVgd0QADqZ1+p233V2cjmG/sCj2dPxuXMh8curogXFOkQt3AzctMPU9akhywYKldkOVvyrx8NKfvFQ5EhDILIH8wAl4FnkWW7lL8JkMYkzhkU4pwqVfJwOc25j8dn49kCgYEAyjUxgUO1jzorOW8Pnq3Pc/Tm3WPgy7HtEJRIhD8g0hDwGQw98+5G08GZ1+HcN4lgmA0P7MrLurgKk30K5dEEOV7sRm8jURm6rLVK315qsro+UjewQM68hgyjdhjUj9Mu/qRs4GQZkVRBbAtQgNuhIdsBxmxs389R/K6VKdfSWgkCgYBq+2MjZNtYZrPSwJrO/m59TQZYSCt660mMzYBTCaLO4uFQHppST5icirBqJF4Vt2PvQ3IJg7CKI2xGSv7qMb2FlkI/ynhNWiTVs0TdO6nSNobK+zwZ0WopymRSy7JtiIJMrrteYHKjieokkXeFiDxlnl8+dsmA5tN2KncINIcZEQKBgFdz2g1F82gWiEs2tVKzaV2FNbPaVobCVP0upI5Nnyw7Fxw+Jy0wiIFc4eR0UoHScGxSeei3bJU8s5ZGJkhutZz6aMWtm2Cf+BRp9A/XDd5unjWA0EG3J+Hx5WBWLNhnRZPsGQqTQFuSTRkla5PPaUjzJzlh+1Rwnczi1LBcHyXBAoGBAI3KtGlsBKchRv7o03LAyGb4FuQMkUri3/7YqcfdFtlboeYGYAhxyocF585O1wuoVK0leyGz3LfHke965XUWVN25D6SCXl1H/SdNQMFCFglQymzJ/ucH5I/0FRtcxURYBf+YfZIEx3YWuT+SUw5/kV50yuC/SBI3OkWLmL+KkPkW" ],
+        "certificate" : [ "MIICpTCCAY0CBgFtJZfOajANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAtkZXZlbG9wbWVudDAeFw0xOTA5MTIxMzA3NDhaFw0yOTA5MTIxMzA5MjhaMBYxFDASBgNVBAMMC2RldmVsb3BtZW50MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuUFncyCZ4pszQ0qH0oX1qTKPP6TekWZR//qX/i+VLVTeKBP5BnSPdq11c9zrQifPJ6thtfhd9Qta7tCd1J0BuSriSdqTC5GIQgV0q8RwBFQNPuqM5847quHyQ6yeT/ZTlymu+Y8uSQvq5I5fG4vfJCnLkvhl4ZSNp0pRxW6O46CGY35mQeezLjt6ntL/zTUG3mbnzG08zt+18JBTNre/y+sxwd4s59LyqD6x98yJA2kcQPx8i9WoiPzXPBDoO8OAM2aWGAPahMe3Fy3sHaRiYIn3Pt7NoeC/60SU1eCSQxfAd7ofzZbNTeTfg38PPwMmRIUvfpr17oQ0oLB9r8NMoQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQA69Q3vN9hMKU3eYaV8weGpr+fb398FSlvXPDiwnoz/4wamvP15Cu2wSSGwT5FwSQxBRrZ3Y+rh0k0EL+AFkasbe46xwOb9R9v++jCEzIFEgzvb/lZfwjMC4+gor0QLfYR62ioDbaIEnXsXdto28I0WNlFs7HR9toG/5D4CVwLCyIhUhdRNdTpSykQgoeAU+N7PCsBWPEm9mbCu6+qftW1vHLuGSTSVQVU/pKY4+5DjpglpK2Jtj38Xy6k+kDI7p5bb7+wjnK4c3IA7oiH3usP/lv5mYoNVE+SEugG/zEzI52ILXG32YCCeywYarQjcS0tFnxjg8Ssj9IA9bmCm0FzA" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "00a6e783-4c05-4ede-903d-46d1c13224ed",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "096adad3-39d5-4d8d-8601-10b7a1b73208" ],
+        "secret" : [ "UROjmfXtEUTPd_vlCW6D6sXjpvkrEer-yGR8qaYKgguvnabsq3KdH2e07D9cCSyku5APcjcWXXgvGmPbbbIqzQ" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "a6f7e517-8086-434a-b135-1671a981568f",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "f2eac6a6-4e7f-4728-a9a3-38454b35676e" ],
+        "secret" : [ "d8j6K93Gbqdcn0LX0jKVLw" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "966cc8db-f912-4136-969e-2e56311cb00a",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "idp-email-verification",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "be40ddaf-ba52-41c2-86a1-c6ed8878dbda",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "requirement" : "OPTIONAL",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "88d006ce-fe78-4dec-8e27-770d96d304f9",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "d1e4f6a5-4792-42c4-a440-39419a7d9291",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-x509",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "a5116d7e-a029-4293-a668-f85c2c03ab90",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "requirement" : "OPTIONAL",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "e2951890-d0e9-48ad-95b5-ff3d48522b4a",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "7f6abdf5-2d73-4a0d-addc-89c94d05f0c4",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "9ae334ad-93d0-4991-9230-588f80a2fb8a",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "requirement" : "OPTIONAL",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "e6249447-9bdf-4551-82c5-a0162e64b4ce",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "basic-auth",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "3c6b5f69-12eb-4952-ae78-4370fb771240",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "b782cfd8-ec15-4f35-98c1-15dbfb44f47f",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "4073b5c6-4a30-47f4-b65b-fa425f82f2b5",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-password",
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "requirement" : "OPTIONAL",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "2ee087fe-5ded-4889-97b8-2a8ed5fefea8",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "8370708e-c5b0-4b4d-adb6-b98784531ceb",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "1a43bbd7-5065-4f03-84aa-e771f9b33592",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "_browser_header.xXSSProtection" : "1; mode=block",
+    "_browser_header.xFrameOptions" : "SAMEORIGIN",
+    "_browser_header.strictTransportSecurity" : "max-age=31536000; includeSubDomains",
+    "permanentLockout" : "false",
+    "quickLoginCheckMilliSeconds" : "1000",
+    "displayName" : "Development",
+    "_browser_header.xRobotsTag" : "none",
+    "maxFailureWaitSeconds" : "900",
+    "minimumQuickLoginWaitSeconds" : "60",
+    "failureFactor" : "30",
+    "actionTokenGeneratedByUserLifespan" : "300",
+    "maxDeltaTimeSeconds" : "43200",
+    "_browser_header.xContentTypeOptions" : "nosniff",
+    "offlineSessionMaxLifespan" : "5184000",
+    "actionTokenGeneratedByAdminLifespan" : "43200",
+    "_browser_header.contentSecurityPolicyReportOnly" : "",
+    "bruteForceProtected" : "false",
+    "_browser_header.contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "waitIncrementSeconds" : "60",
+    "offlineSessionMaxLifespanEnabled" : "false"
+  },
+  "keycloakVersion" : "7.0.0",
+  "userManagedAccessAllowed" : false
+}

--- a/scripts/docker/auth/openldap/Dockerfile
+++ b/scripts/docker/auth/openldap/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:10
+
+# For some reason some people get hash mismatch issues. This tries to resolve that.
+# See https://askubuntu.com/questions/1121093/hash-sum-mismatches-in-18-04-on-laptop-and-in-docker
+RUN printf "Acquire::http::Pipeline-Depth 0;\nAcquire::http::No-Cache true;\nAcquire::BrokenProxy true;" > /etc/apt/apt.conf.d/99fixbadproxy
+
+RUN sed -i -e 's%http://deb.debian.org/debian%http://ftp.uk.debian.org/debian%g' /etc/apt/sources.list && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y slapd ldap-utils ldapscripts && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /etc/ldap/schema
+
+ADD schema/* /etc/ldap/schema/
+ADD slapd.conf base.ldif /etc/ldap/
+RUN rm -rf /etc/ldap/slapd.d/* && \
+  mkdir -p /var/run/openldap && \
+  slaptest -f /etc/ldap/slapd.conf -F /etc/ldap/slapd.d && \
+  slapadd -F /etc/ldap/slapd.d -l /etc/ldap/base.ldif && \
+  rm /etc/ldap/base.ldif && \
+  chown -R openldap:openldap /etc/ldap/slapd.d /var/run/openldap
+
+EXPOSE 389
+VOLUME /var/lib/ldap
+
+ENTRYPOINT ["slapd", "-u", "openldap", "-g", "openldap", "-h", "ldap:///", "-d", "stats,stats2"]

--- a/scripts/docker/auth/openldap/base.ldif
+++ b/scripts/docker/auth/openldap/base.ldif
@@ -1,0 +1,9 @@
+dn: dc=dev,dc=domain
+objectclass: dcObject
+objectclass: organization
+o: Development
+dc: dev
+
+dn: cn=admin,dc=dev,dc=domain
+objectclass: organizationalRole
+cn: admin

--- a/scripts/docker/auth/openldap/schema/collective.schema
+++ b/scripts/docker/auth/openldap/schema/collective.schema
@@ -1,0 +1,190 @@
+# collective.schema -- Collective attribute schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (2003).
+## Please see full copyright statement below.
+
+# From RFC 3671 [portions trimmed]:
+# 	Collective Attributes in LDAP
+
+#Abstract
+#
+#  X.500 collective attributes allow common characteristics to be shared
+#  between collections of entries.  This document summarizes the X.500
+#  information model for collective attributes and describes use of
+#  collective attributes in LDAP (Lightweight Directory Access Protocol).
+#  This document provides schema definitions for collective attributes
+#  for use in LDAP.
+
+#3. Collective Attribute Types
+#
+#  A userApplications attribute type can be defined to be COLLECTIVE
+#  [RFC2252].  This indicates that the same attribute values will appear
+#  in the entries of an entry collection subject to the use of the
+#  collectiveExclusions attribute and other administrative controls.
+#
+#  Collective attribute types are commonly defined as subtypes of non-
+#  collective attribute types.  By convention, collective attributes are
+#  named by prefixing the name of their non-collective supertype with
+#  "c-".  For example, the collective telephone attribute is named
+#  c-TelephoneNumber after its non-collective supertype telephoneNumber.
+#
+#  Non-collective attributes types SHALL NOT subtype collective
+#  attributes.
+#
+#  Collective attributes SHALL NOT be SINGLE-VALUED.  Collective
+#  attribute types SHALL NOT appear in the attribute types of an object
+#  class definition.
+#
+#  Operational attributes SHALL NOT be defined to be collective.
+#
+#  The remainder of section provides a summary of collective attributes
+#  derived from those defined in [X.520].  Implementations of this
+#  specification SHOULD support the following collective attributes and
+#  MAY support additional collective attributes.
+#
+#
+#3.1. Collective Locality Name
+#
+#  The c-l attribute type specifies a locality name for a collection of
+#  entries.
+#
+attributeType      ( 2.5.4.7.1 NAME 'c-l'
+	SUP l COLLECTIVE )
+#
+#
+#3.2. Collective State or Province Name
+#
+#  The c-st attribute type specifies a state or province name for a
+#  collection of entries.
+#
+attributeType      ( 2.5.4.8.1 NAME 'c-st'
+	SUP st COLLECTIVE )
+#
+#
+#3.3. Collective Street Address
+#
+#  The c-street attribute type specifies a street address for a
+#  collection of entries.
+#
+attributeType      ( 2.5.4.9.1 NAME 'c-street'
+	SUP street COLLECTIVE )
+#
+#
+#3.4. Collective Organization Name
+#
+#  The c-o attribute type specifies an organization name for a collection
+#  of entries.
+#
+attributeType      ( 2.5.4.10.1 NAME 'c-o'
+	SUP o COLLECTIVE )
+#
+#
+#3.5. Collective Organizational Unit Name
+#
+#  The c-ou attribute type specifies an organizational unit name for a
+#  collection of entries.
+#
+attributeType      ( 2.5.4.11.1 NAME 'c-ou'
+	SUP ou COLLECTIVE )
+#
+#
+#3.6. Collective Postal Address
+#
+#  The c-PostalAddress attribute type specifies a postal address for a
+#  collection of entries.
+#
+attributeType      ( 2.5.4.16.1 NAME 'c-PostalAddress'
+	SUP postalAddress COLLECTIVE )
+#
+#
+#3.7. Collective Postal Code
+#
+#  The c-PostalCode attribute type specifies a postal code for a
+#  collection of entries.
+#
+attributeType      ( 2.5.4.17.1 NAME 'c-PostalCode'
+	SUP postalCode COLLECTIVE )
+#
+#
+#3.8. Collective Post Office Box
+#
+#  The c-PostOfficeBox attribute type specifies a post office box for a
+#  collection of entries.
+#
+attributeType ( 2.5.4.18.1 NAME 'c-PostOfficeBox'
+	SUP postOfficeBox COLLECTIVE )
+#
+#
+#3.9. Collective Physical Delivery Office Name
+#
+#  The c-PhysicalDeliveryOfficeName attribute type specifies a physical
+#  delivery office name for a collection of entries.
+#
+attributeType ( 2.5.4.19.1 NAME 'c-PhysicalDeliveryOfficeName'
+	SUP physicalDeliveryOfficeName COLLECTIVE )
+#
+#
+#3.10. Collective Telephone Number
+#
+#  The c-TelephoneNumber attribute type specifies a telephone number for
+#  a collection of entries.
+#
+attributeType ( 2.5.4.20.1 NAME 'c-TelephoneNumber'
+	SUP telephoneNumber COLLECTIVE )
+#
+#
+#3.11. Collective Telex Number
+#
+#  The c-TelexNumber attribute type specifies a telex number for a
+#  collection of entries.
+#
+attributeType ( 2.5.4.21.1 NAME 'c-TelexNumber'
+	SUP telexNumber COLLECTIVE )
+#
+#
+#3.13. Collective Facsimile Telephone Number
+#
+#  The c-FacsimileTelephoneNumber attribute type specifies a facsimile
+#  telephone number for a collection of entries.
+#
+attributeType ( 2.5.4.23.1 NAME 'c-FacsimileTelephoneNumber'
+	SUP facsimileTelephoneNumber COLLECTIVE )
+#
+#
+#3.14. Collective International ISDN Number
+#
+#  The c-InternationalISDNNumber attribute type specifies an
+#  international ISDN number for a collection of entries.
+#
+attributeType ( 2.5.4.25.1 NAME 'c-InternationalISDNNumber'
+	SUP internationalISDNNumber COLLECTIVE )
+
+# Full Copyright
+#
+# Copyright (C) The Internet Society (2003). All Rights Reserved.
+# 
+# This document and translations of it may be copied and furnished
+# to others, and derivative works that comment on or otherwise explain
+# it or assist in its implmentation may be prepared, copied, published
+# and distributed, in whole or in part, without restriction of any
+# kind, provided that the above copyright notice and this paragraph
+# are included on all such copies and derivative works.  However,
+# this document itself may not be modified in any way, such as by
+# removing the copyright notice or references to the Internet Society
+# or other Internet organizations, except as needed for the  purpose
+# of developing Internet standards in which case the procedures for
+# copyrights defined in the Internet Standards process must be followed,
+# or as required to translate it into languages other than English.

--- a/scripts/docker/auth/openldap/schema/corba.schema
+++ b/scripts/docker/auth/openldap/schema/corba.schema
@@ -1,0 +1,239 @@
+# corba.schema -- Corba Object Schema
+#	depends upon core.schema
+# $OpenLDAP$
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (1999).
+## Please see full copyright statement below.
+
+
+# Network Working Group                                            V. Ryan
+# Request for Comments: 2714                                        R. Lee
+# Category: Informational                                      S. Seligman
+#                                                   Sun Microsystems, Inc.
+#                                                             October 1999
+# 
+# 
+#   Schema for Representing CORBA Object References in an LDAP Directory
+# 
+# Status of this Memo
+# 
+#    This memo provides information for the Internet community.  It does
+#    not specify an Internet standard of any kind.  Distribution of this
+#    memo is unlimited.
+# 
+# Copyright Notice
+# 
+#    Copyright (C) The Internet Society (1999).  All Rights Reserved.
+# 
+# Abstract
+# 
+#    CORBA [CORBA] is the Common Object Request Broker Architecture
+#    defined by the Object Management Group. This document defines the
+#    schema for representing CORBA object references in an LDAP directory
+#    [LDAPv3].
+# 
+# [trimmed]
+
+# 3. Attribute Type Definitions
+# 
+#    The following attribute types are defined in this document:
+# 
+#        corbaIor
+#        corbaRepositoryId
+# 
+# 3.1 corbaIor
+# 
+#    This attribute stores the string representation of the interoperable
+#    object reference (IOR) for a CORBA object. An IOR is an opaque handle
+#    for the object which contains the information necessary to locate the
+#    object, even if the object is in another ORB.
+# 
+#    This attribute's syntax is 'IA5 String' and its case is
+#    insignificant.
+# 
+#    ( 1.3.6.1.4.1.42.2.27.4.1.14
+#     NAME 'corbaIor'
+#     DESC 'Stringified interoperable object reference of a CORBA object'
+#     EQUALITY caseIgnoreIA5Match
+#     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+#     SINGLE-VALUE
+#    )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.14
+	NAME 'corbaIor'
+	DESC 'Stringified interoperable object reference of a CORBA object'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+	SINGLE-VALUE )
+
+# 3.2 corbaRepositoryId
+# 
+#    Each CORBA interface has a unique "repository id" (also called "type
+#    id") that identifies the interface.  A CORBA object has one or more
+#    repository ids, one for each interface that it implements.
+# 
+#    The format of a repository id can be any string, but the OMG
+#    specifies four standard formats:
+# 
+#       a. IDL-style
+# 
+#        IDL:Prefix/ModuleName/InterfaceName:VersionNumber
+# 
+#    For example, the repository id for the "NamingContext" in OMG's COS
+#    Naming module is:  "IDL:omg.org/CosNaming/NamingContext:1.0".
+# 
+#       b. RMI-style
+# 
+#        RMI:ClassName:HashCode[:SUID]
+# 
+#    This format is used by RMI-IIOP remote objects [RMI-IIOP].
+#    "ClassName" is the fully qualified name of the class (for example,
+#    "java.lang.String"). "HashCode" is the object's hash code (that is,
+#    that obtained by invoking the "hashCode()" method).  "SUID" is the
+#    "stream unique identifier", which is a 64-bit number that uniquely
+#    identifies the serialization version of the class; SUID is optional
+#    in the repository id.
+# 
+#       c. DCE-style
+# 
+#        DCE:UUID
+# 
+#    This format is used for DCE/CORBA interoperability [CORBA-DCE].
+#    "UUID" represents a DCE UUID.
+# 
+#       d. "local"
+# 
+#    This format is defined by the local Object Request Broker (ORB).
+# 
+#    The corbaRepositoryId attribute is a multivalued attribute; each
+#    value records a single repository id of an interface implemented by
+#    the CORBA object.  This attribute need not contain a complete list of
+#    the interfaces implemented by the CORBA object.
+# 
+#    This attribute's syntax is 'Directory String' and its case is
+#    significant.  The values of this attribute are encoded using UTF-8.
+#    Some values may require translation from their native representation
+#    in order to be correctly encoded using UTF-8.
+# 
+#    ( 1.3.6.1.4.1.42.2.27.4.1.15
+#     NAME 'corbaRepositoryId'
+#     DESC 'Repository ids of interfaces implemented by a CORBA object'
+#     EQUALITY caseExactMatch
+#     SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+#    )
+# 
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.15
+	NAME 'corbaRepositoryId'
+	DESC 'Repository ids of interfaces implemented by a CORBA object'
+	EQUALITY caseExactMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# 4. Object Class Definitions
+# 
+#    The following object classes are defined in this document:
+# 
+#        corbaContainer
+#        corbaObject
+#        corbaObjectReference
+# 
+# 4.1 corbaContainer
+# 
+#    This structural object class represents a container for a CORBA
+#    object.
+# 
+#    ( 1.3.6.1.4.1.42.2.27.4.2.10
+#     NAME 'corbaContainer'
+#     DESC 'Container for a CORBA object'
+#     SUP top
+#     STRUCTURAL
+#     MUST ( cn )
+#    )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.10
+	NAME 'corbaContainer'
+	DESC 'Container for a CORBA object'
+	SUP top
+	STRUCTURAL
+	MUST cn )
+
+# 4.2 corbaObject
+# 
+#    This abstract object class is the root class for representing a CORBA
+#    object.
+# 
+#    ( 1.3.6.1.4.1.42.2.27.4.2.9
+#     NAME 'corbaObject'
+#     DESC 'CORBA object representation'
+#     SUP top
+#     ABSTRACT
+#     MAY ( corbaRepositoryId $ description )
+#    )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.9
+	NAME 'corbaObject'
+	DESC 'CORBA object representation'
+	SUP top
+	ABSTRACT
+	MAY ( corbaRepositoryId $ description ) )
+
+# 4.3 corbaObjectReference
+# 
+#    This auxiliary object class represents a CORBA object reference.  It
+#    must be mixed in with a structural object class.
+# 
+#    ( 1.3.6.1.4.1.42.2.27.4.2.11
+#     NAME 'corbaObjectReference'
+#     DESC 'CORBA interoperable object reference'
+#     SUP corbaObject
+#     AUXILIARY
+#     MUST ( corbaIor )
+#    )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.11
+	NAME 'corbaObjectReference'
+	DESC 'CORBA interoperable object reference'
+	SUP corbaObject
+	AUXILIARY
+	MUST corbaIor )
+ 
+# 10.  Full Copyright Statement
+#
+#    Copyright (C) The Internet Society (1999).  All Rights Reserved.
+# 
+#    This document and translations of it may be copied and furnished to
+#    others, and derivative works that comment on or otherwise explain it
+#    or assist in its implementation may be prepared, copied, published
+#    and distributed, in whole or in part, without restriction of any
+#    kind, provided that the above copyright notice and this paragraph are
+#    included on all such copies and derivative works.  However, this
+#    document itself may not be modified in any way, such as by removing
+#    the copyright notice or references to the Internet Society or other
+#    Internet organizations, except as needed for the purpose of
+#    developing Internet standards in which case the procedures for
+#    copyrights defined in the Internet Standards process must be
+#    followed, or as required to translate it into languages other than
+#    English.
+# 
+#    The limited permissions granted above are perpetual and will not be
+#    revoked by the Internet Society or its successors or assigns.
+# 
+#    This document and the information contained herein is provided on an
+#    "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+#    TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+#    BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+#    HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+#    MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.

--- a/scripts/docker/auth/openldap/schema/core.schema
+++ b/scripts/docker/auth/openldap/schema/core.schema
@@ -1,0 +1,667 @@
+# OpenLDAP Core schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (1997-2006).
+## All Rights Reserved.
+##
+## This document and translations of it may be copied and furnished to
+## others, and derivative works that comment on or otherwise explain it
+## or assist in its implementation may be prepared, copied, published
+## and distributed, in whole or in part, without restriction of any
+## kind, provided that the above copyright notice and this paragraph are
+## included on all such copies and derivative works.  However, this
+## document itself may not be modified in any way, such as by removing
+## the copyright notice or references to the Internet Society or other
+## Internet organizations, except as needed for the purpose of
+## developing Internet standards in which case the procedures for
+## copyrights defined in the Internet Standards process must be         
+## followed, or as required to translate it into languages other than
+## English.
+##                                                                      
+## The limited permissions granted above are perpetual and will not be  
+## revoked by the Internet Society or its successors or assigns.        
+## 
+## This document and the information contained herein is provided on an 
+## "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+## TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+## BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+## HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+## MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+#
+#
+# Includes LDAPv3 schema items from:
+#	RFC 2252/2256 (LDAPv3)
+#
+# Select standard track schema items:
+#	RFC 1274 (uid/dc)
+#	RFC 2079 (URI)
+#	RFC 2247 (dc/dcObject)
+#	RFC 2587 (PKI)
+#	RFC 2589 (Dynamic Directory Services)
+#	RFC 4524 (associatedDomain)
+#
+# Select informational schema items:
+#	RFC 2377 (uidObject)
+
+#
+# Standard attribute types from RFC 2256
+#
+
+# system schema
+#attributetype ( 2.5.4.0 NAME 'objectClass'
+#	DESC 'RFC2256: object classes of the entity'
+#	EQUALITY objectIdentifierMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 )
+
+# system schema
+#attributetype ( 2.5.4.1 NAME ( 'aliasedObjectName' 'aliasedEntryName' )
+#	DESC 'RFC2256: name of aliased object'
+#	EQUALITY distinguishedNameMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE )
+
+attributetype ( 2.5.4.2 NAME 'knowledgeInformation'
+	DESC 'RFC2256: knowledge information'
+	EQUALITY caseIgnoreMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} )
+
+# system schema
+#attributetype ( 2.5.4.3 NAME ( 'cn' 'commonName' )
+#	DESC 'RFC2256: common name(s) for which the entity is known by'
+#	SUP name )
+
+attributetype ( 2.5.4.4 NAME ( 'sn' 'surname' )
+	DESC 'RFC2256: last (family) name(s) for which the entity is known by'
+	SUP name )
+
+attributetype ( 2.5.4.5 NAME 'serialNumber'
+	DESC 'RFC2256: serial number of the entity'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{64} )
+
+# RFC 4519 definition ('countryName' in X.500 and RFC2256)
+attributetype ( 2.5.4.6 NAME ( 'c' 'countryName' )
+	DESC 'RFC4519: two-letter ISO-3166 country code'
+	SUP name
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.11
+	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.6 NAME ( 'c' 'countryName' )
+#	DESC 'RFC2256: ISO-3166 country 2-letter code'
+#	SUP name SINGLE-VALUE )
+
+attributetype ( 2.5.4.7 NAME ( 'l' 'localityName' )
+	DESC 'RFC2256: locality which this object resides in'
+	SUP name )
+
+attributetype ( 2.5.4.8 NAME ( 'st' 'stateOrProvinceName' )
+	DESC 'RFC2256: state or province which this object resides in'
+	SUP name )
+
+attributetype ( 2.5.4.9 NAME ( 'street' 'streetAddress' )
+	DESC 'RFC2256: street address of this object'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} )
+
+attributetype ( 2.5.4.10 NAME ( 'o' 'organizationName' )
+	DESC 'RFC2256: organization this object belongs to'
+	SUP name )
+
+attributetype ( 2.5.4.11 NAME ( 'ou' 'organizationalUnitName' )
+	DESC 'RFC2256: organizational unit this object belongs to'
+	SUP name )
+
+attributetype ( 2.5.4.12 NAME 'title'
+	DESC 'RFC2256: title associated with the entity'
+	SUP name )
+
+# system schema
+#attributetype ( 2.5.4.13 NAME 'description'
+#	DESC 'RFC2256: descriptive information'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+
+# Deprecated by enhancedSearchGuide
+attributetype ( 2.5.4.14 NAME 'searchGuide'
+	DESC 'RFC2256: search guide, deprecated by enhancedSearchGuide'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.25 )
+
+attributetype ( 2.5.4.15 NAME 'businessCategory'
+	DESC 'RFC2256: business category'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} )
+
+attributetype ( 2.5.4.16 NAME 'postalAddress'
+	DESC 'RFC2256: postal address'
+	EQUALITY caseIgnoreListMatch
+	SUBSTR caseIgnoreListSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+
+attributetype ( 2.5.4.17 NAME 'postalCode'
+	DESC 'RFC2256: postal code'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40} )
+
+attributetype ( 2.5.4.18 NAME 'postOfficeBox'
+	DESC 'RFC2256: Post Office Box'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40} )
+
+attributetype ( 2.5.4.19 NAME 'physicalDeliveryOfficeName'
+	DESC 'RFC2256: Physical Delivery Office Name'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} )
+
+attributetype ( 2.5.4.20 NAME 'telephoneNumber'
+	DESC 'RFC2256: Telephone Number'
+	EQUALITY telephoneNumberMatch
+	SUBSTR telephoneNumberSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50{32} )
+
+attributetype ( 2.5.4.21 NAME 'telexNumber'
+	DESC 'RFC2256: Telex Number'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.52 )
+
+attributetype ( 2.5.4.22 NAME 'teletexTerminalIdentifier'
+	DESC 'RFC2256: Teletex Terminal Identifier'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.51 )
+
+attributetype ( 2.5.4.23 NAME ( 'facsimileTelephoneNumber' 'fax' )
+	DESC 'RFC2256: Facsimile (Fax) Telephone Number'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.22 )
+
+attributetype ( 2.5.4.24 NAME 'x121Address'
+	DESC 'RFC2256: X.121 Address'
+	EQUALITY numericStringMatch
+	SUBSTR numericStringSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{15} )
+
+attributetype ( 2.5.4.25 NAME 'internationaliSDNNumber'
+	DESC 'RFC2256: international ISDN number'
+	EQUALITY numericStringMatch
+	SUBSTR numericStringSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{16} )
+
+attributetype ( 2.5.4.26 NAME 'registeredAddress'
+	DESC 'RFC2256: registered postal address'
+	SUP postalAddress
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+
+attributetype ( 2.5.4.27 NAME 'destinationIndicator'
+	DESC 'RFC2256: destination indicator'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{128} )
+
+attributetype ( 2.5.4.28 NAME 'preferredDeliveryMethod'
+	DESC 'RFC2256: preferred delivery method'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.14
+	SINGLE-VALUE )
+
+attributetype ( 2.5.4.29 NAME 'presentationAddress'
+	DESC 'RFC2256: presentation address'
+	EQUALITY presentationAddressMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.43
+	SINGLE-VALUE )
+
+attributetype ( 2.5.4.30 NAME 'supportedApplicationContext'
+	DESC 'RFC2256: supported application context'
+	EQUALITY objectIdentifierMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 )
+
+attributetype ( 2.5.4.31 NAME 'member'
+	DESC 'RFC2256: member of a group'
+	SUP distinguishedName )
+
+attributetype ( 2.5.4.32 NAME 'owner'
+	DESC 'RFC2256: owner (of the object)'
+	SUP distinguishedName )
+
+attributetype ( 2.5.4.33 NAME 'roleOccupant'
+	DESC 'RFC2256: occupant of role'
+	SUP distinguishedName )
+
+# system schema
+#attributetype ( 2.5.4.34 NAME 'seeAlso'
+#	DESC 'RFC2256: DN of related object'
+#	SUP distinguishedName )
+
+# system schema
+#attributetype ( 2.5.4.35 NAME 'userPassword'
+#	DESC 'RFC2256/2307: password of user'
+#	EQUALITY octetStringMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.40{128} )
+
+# 2.5.4.36 NAME 'userCertificate' Changed: 
+#   SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 -> 1.3.6.1.4.1.1466.115.121.1.40 
+#   EQUALITY certificateExactMatch -> {none}
+#
+## Must be transferred using ;binary
+## with certificateExactMatch rule (per X.509)
+#attributetype ( 2.5.4.36 NAME 'userCertificate'
+#	DESC 'RFC2256: X.509 user certificate, use ;binary'
+#	EQUALITY certificateExactMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 )
+attributetype ( 2.5.4.36 NAME 'userCertificate'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
+
+# Must be transferred using ;binary
+# with certificateExactMatch rule (per X.509)
+attributetype ( 2.5.4.37 NAME 'cACertificate'
+	DESC 'RFC2256: X.509 CA certificate, use ;binary'
+	EQUALITY certificateExactMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 )
+
+# Must be transferred using ;binary
+attributetype ( 2.5.4.38 NAME 'authorityRevocationList'
+	DESC 'RFC2256: X.509 authority revocation list, use ;binary'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 )
+
+# Must be transferred using ;binary
+attributetype ( 2.5.4.39 NAME 'certificateRevocationList'
+	DESC 'RFC2256: X.509 certificate revocation list, use ;binary'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 )
+
+# Must be stored and requested in the binary form
+attributetype ( 2.5.4.40 NAME 'crossCertificatePair'
+	DESC 'RFC2256: X.509 cross certificate pair, use ;binary'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.10 )
+
+# system schema
+#attributetype ( 2.5.4.41 NAME 'name'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} )
+
+attributetype ( 2.5.4.42 NAME ( 'givenName' 'gn' )
+	DESC 'RFC2256: first name(s) for which the entity is known by'
+	SUP name )
+
+attributetype ( 2.5.4.43 NAME 'initials'
+	DESC 'RFC2256: initials of some or all of names, but not the surname(s).'
+	SUP name )
+
+attributetype ( 2.5.4.44 NAME 'generationQualifier'
+	DESC 'RFC2256: name qualifier indicating a generation'
+	SUP name )
+
+attributetype ( 2.5.4.45 NAME 'x500UniqueIdentifier'
+	DESC 'RFC2256: X.500 unique identifier'
+	EQUALITY bitStringMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.6 )
+
+attributetype ( 2.5.4.46 NAME 'dnQualifier'
+	DESC 'RFC2256: DN qualifier'
+	EQUALITY caseIgnoreMatch
+	ORDERING caseIgnoreOrderingMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.44 )
+
+attributetype ( 2.5.4.47 NAME 'enhancedSearchGuide'
+	DESC 'RFC2256: enhanced search guide'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.21 )
+
+attributetype ( 2.5.4.48 NAME 'protocolInformation'
+	DESC 'RFC2256: protocol information'
+	EQUALITY protocolInformationMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.42 )
+
+# system schema
+#attributetype ( 2.5.4.49 NAME 'distinguishedName'
+#	EQUALITY distinguishedNameMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+attributetype ( 2.5.4.50 NAME 'uniqueMember'
+	DESC 'RFC2256: unique member of a group'
+	EQUALITY uniqueMemberMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.34 )
+
+attributetype ( 2.5.4.51 NAME 'houseIdentifier'
+	DESC 'RFC2256: house identifier'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} )
+
+# Must be transferred using ;binary
+attributetype ( 2.5.4.52 NAME 'supportedAlgorithms'
+	DESC 'RFC2256: supported algorithms'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.49 )
+
+# Must be transferred using ;binary
+attributetype ( 2.5.4.53 NAME 'deltaRevocationList'
+	DESC 'RFC2256: delta revocation list; use ;binary'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 )
+
+attributetype ( 2.5.4.54 NAME 'dmdName'
+	DESC 'RFC2256: name of DMD'
+	SUP name )
+
+attributetype ( 2.5.4.65 NAME 'pseudonym'
+	DESC 'X.520(4th): pseudonym for the object'
+	SUP name )
+
+# 9.3.33.  Friendly Country Name
+#
+#  The Friendly Country Name attribute type specifies names of countries
+#  in human readable format.  The standard attribute country name must
+#  be one of the two-letter codes defined in ISO 3166.
+#
+#    friendlyCountryName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#    ::= {pilotAttributeType 43}
+#
+attributetype ( 0.9.2342.19200300.100.1.43
+	NAME ( 'co' 'friendlyCountryName' )
+	DESC 'RFC1274: friendly country name'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# 9.3.4.  Information
+#
+#  The Information attribute type specifies any general information
+#  pertinent to an object.  It is recommended that specific usage of
+#  this attribute type is avoided, and that specific requirements are
+#  met by other (possibly additional) attribute types.
+#
+#    info ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-information))
+#    ::= {pilotAttributeType 4}
+#
+attributetype ( 0.9.2342.19200300.100.1.4 NAME 'info'
+	DESC 'RFC1274: general information'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{2048} )
+
+#
+# Derived from RFC 1274, but with new "short names"
+#
+#attributetype ( 0.9.2342.19200300.100.1.1
+#	NAME ( 'uid' 'userid' )
+#	DESC 'RFC1274: user identifier'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+attributetype ( 0.9.2342.19200300.100.1.3
+	NAME ( 'mail' 'rfc822Mailbox' )
+	DESC 'RFC1274: RFC822 Mailbox'
+    EQUALITY caseIgnoreIA5Match
+    SUBSTR caseIgnoreIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+
+# Standard object classes from RFC2256
+
+# system schema
+#objectclass ( 2.5.6.0 NAME 'top'
+#	DESC 'RFC2256: top of the superclass chain'
+#	ABSTRACT
+#	MUST objectClass )
+
+# system schema
+#objectclass ( 2.5.6.1 NAME 'alias'
+#	DESC 'RFC2256: an alias'
+#	SUP top STRUCTURAL
+#	MUST aliasedObjectName )
+
+objectclass ( 2.5.6.2 NAME 'country'
+	DESC 'RFC2256: a country'
+	SUP top STRUCTURAL
+	MUST c
+	MAY ( searchGuide $ description ) )
+
+objectclass ( 2.5.6.3 NAME 'locality'
+	DESC 'RFC2256: a locality'
+	SUP top STRUCTURAL
+	MAY ( street $ seeAlso $ searchGuide $ st $ l $ description ) )
+
+objectclass ( 2.5.6.4 NAME 'organization'
+	DESC 'RFC2256: an organization'
+	SUP top STRUCTURAL
+	MUST o
+	MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+		x121Address $ registeredAddress $ destinationIndicator $
+		preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+		telephoneNumber $ internationaliSDNNumber $ 
+		facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+		postalAddress $ physicalDeliveryOfficeName $ st $ l $ description ) )
+
+# 2.5.6.5 NAME 'organizationalUnit' Mixed: OpenLdap + Microsoft
+objectclass ( 2.5.6.5 NAME 'organizationalUnit'
+	DESC 'RFC2256: an organizational unit + Microsoft hacks'
+	SUP top STRUCTURAL
+	MUST ou
+	MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+		x121Address $ registeredAddress $ destinationIndicator $
+		preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+		telephoneNumber $ internationaliSDNNumber $
+		facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+		postalAddress $ physicalDeliveryOfficeName $ st $ l $ description $
+        c $ internationalISDNNumber $ co $ countryCode $ desktopProfile $
+        defaultGroup $ managedBy $ uPNSuffixes $ gPLink $ gPOptions $ thumbnailLogo
+        ) )
+
+# 2.5.6.6 NAME 'person' Changed: MUST (sn) -> MUST (cn)
+objectclass ( 2.5.6.6 NAME 'person'
+	DESC 'RFC2256: a person'
+	SUP top STRUCTURAL
+	MUST ( cn )
+	MAY ( userPassword $ telephoneNumber $ seeAlso $ description $ sn ) )
+
+# 2.5.6.7 NAME 'organizationalPerson' Mixed: OpenLdap + Microsoft
+objectclass ( 2.5.6.7 NAME 'organizationalPerson'
+	DESC 'RFC2256: an organizational person'
+	SUP person STRUCTURAL
+	MAY ( title $ x121Address $ registeredAddress $ destinationIndicator $
+		preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+		telephoneNumber $ internationaliSDNNumber $ 
+		facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+		postalAddress $ physicalDeliveryOfficeName $ ou $ st $ l $ c $ co $ info $ mailNickname $
+        o $ internationalISDNNumber $ givenName $ initials $ generationQualifier $
+        otherTelephone $ otherPager $ department $ company $ streetAddress $ otherHomePhone $
+        personalTitle $ homePostalAddress $ countryCode $ employeeID $ comment $ division $
+        otherFacsimileTelephoneNumber $ otherMobile $ primaryTelexNumber $
+        primaryInternationalISDNNumber $ mhsORAddress $ otherMailbox $ assistant $
+        ipPhone $ otherIpPhone $ mail $ manager $ homePhone $ mobile $ pager $ middleName $
+        thumbnailPhoto $ thumbnailLogo
+        ) )
+
+objectclass ( 2.5.6.8 NAME 'organizationalRole'
+	DESC 'RFC2256: an organizational role'
+	SUP top STRUCTURAL
+	MUST cn
+	MAY ( x121Address $ registeredAddress $ destinationIndicator $
+		preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+		telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+		seeAlso $ roleOccupant $ preferredDeliveryMethod $ street $
+		postOfficeBox $ postalCode $ postalAddress $
+		physicalDeliveryOfficeName $ ou $ st $ l $ description ) )
+
+objectclass ( 2.5.6.9 NAME 'groupOfNames'
+	DESC 'RFC2256: a group of names (DNs)'
+	SUP top STRUCTURAL
+	MUST ( member $ cn )
+	MAY ( businessCategory $ seeAlso $ owner $ ou $ o $ description ) )
+
+objectclass ( 2.5.6.10 NAME 'residentialPerson'
+	DESC 'RFC2256: an residential person'
+	SUP person STRUCTURAL
+	MUST l
+	MAY ( businessCategory $ x121Address $ registeredAddress $
+		destinationIndicator $ preferredDeliveryMethod $ telexNumber $
+		teletexTerminalIdentifier $ telephoneNumber $ internationaliSDNNumber $
+		facsimileTelephoneNumber $ preferredDeliveryMethod $ street $
+		postOfficeBox $ postalCode $ postalAddress $
+		physicalDeliveryOfficeName $ st $ l ) )
+
+objectclass ( 2.5.6.11 NAME 'applicationProcess'
+	DESC 'RFC2256: an application process'
+	SUP top STRUCTURAL
+	MUST cn
+	MAY ( seeAlso $ ou $ l $ description ) )
+
+objectclass ( 2.5.6.12 NAME 'applicationEntity'
+	DESC 'RFC2256: an application entity'
+	SUP top STRUCTURAL
+	MUST ( presentationAddress $ cn )
+	MAY ( supportedApplicationContext $ seeAlso $ ou $ o $ l $
+	description ) )
+
+objectclass ( 2.5.6.13 NAME 'dSA'
+	DESC 'RFC2256: a directory system agent (a server)'
+	SUP applicationEntity STRUCTURAL
+	MAY knowledgeInformation )
+
+objectclass ( 2.5.6.14 NAME 'device'
+	DESC 'RFC2256: a device'
+	SUP top STRUCTURAL
+	MUST cn
+	MAY ( serialNumber $ seeAlso $ owner $ ou $ o $ l $ description ) )
+
+objectclass ( 2.5.6.15 NAME 'strongAuthenticationUser'
+	DESC 'RFC2256: a strong authentication user'
+	SUP top AUXILIARY
+	MUST userCertificate )
+
+objectclass ( 2.5.6.16 NAME 'certificationAuthority'
+	DESC 'RFC2256: a certificate authority'
+	SUP top AUXILIARY
+	MUST ( authorityRevocationList $ certificateRevocationList $
+		cACertificate ) MAY crossCertificatePair )
+
+objectclass ( 2.5.6.17 NAME 'groupOfUniqueNames'
+	DESC 'RFC2256: a group of unique names (DN and Unique Identifier)'
+	SUP top STRUCTURAL
+	MUST ( uniqueMember $ cn )
+	MAY ( businessCategory $ seeAlso $ owner $ ou $ o $ description ) )
+
+objectclass ( 2.5.6.18 NAME 'userSecurityInformation'
+	DESC 'RFC2256: a user security information'
+	SUP top AUXILIARY
+	MAY ( supportedAlgorithms ) )
+
+objectclass ( 2.5.6.16.2 NAME 'certificationAuthority-V2'
+	SUP certificationAuthority
+	AUXILIARY MAY ( deltaRevocationList ) )
+
+objectclass ( 2.5.6.19 NAME 'cRLDistributionPoint'
+	SUP top STRUCTURAL
+	MUST ( cn )
+	MAY ( certificateRevocationList $ authorityRevocationList $
+		deltaRevocationList ) )
+
+objectclass ( 2.5.6.20 NAME 'dmd'
+	SUP top STRUCTURAL
+	MUST ( dmdName )
+	MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+		x121Address $ registeredAddress $ destinationIndicator $
+		preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+		telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+		street $ postOfficeBox $ postalCode $ postalAddress $
+		physicalDeliveryOfficeName $ st $ l $ description ) )
+
+#
+# Object Classes from RFC 2587
+#
+objectclass ( 2.5.6.21 NAME 'pkiUser'
+	DESC 'RFC2587: a PKI user'
+	SUP top AUXILIARY
+	MAY userCertificate )
+
+objectclass ( 2.5.6.22 NAME 'pkiCA'
+	DESC 'RFC2587: PKI certificate authority'
+	SUP top AUXILIARY
+	MAY ( authorityRevocationList $ certificateRevocationList $
+		cACertificate $ crossCertificatePair ) )
+
+objectclass ( 2.5.6.23 NAME 'deltaCRL'
+	DESC 'RFC2587: PKI user'
+	SUP top AUXILIARY
+	MAY deltaRevocationList )
+
+#
+# Standard Track URI label schema from RFC 2079
+# system schema
+#attributetype ( 1.3.6.1.4.1.250.1.57 NAME 'labeledURI'
+#	DESC 'RFC2079: Uniform Resource Identifier with optional label'
+#	EQUALITY caseExactMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+objectclass ( 1.3.6.1.4.1.250.3.15 NAME 'labeledURIObject'
+	DESC 'RFC2079: object that contains the URI attribute type'
+	SUP top AUXILIARY
+	MAY ( labeledURI ) )
+
+objectclass ( 0.9.2342.19200300.100.4.19 NAME 'simpleSecurityObject'
+	DESC 'RFC1274: simple security object'
+	SUP top AUXILIARY
+	MUST userPassword )
+
+# RFC 1274 + RFC 2247
+attributetype ( 0.9.2342.19200300.100.1.25
+	NAME ( 'dc' 'domainComponent' )
+	DESC 'RFC1274/2247: domain component'
+	EQUALITY caseIgnoreIA5Match
+	SUBSTR caseIgnoreIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+# RFC 2247
+objectclass ( 1.3.6.1.4.1.1466.344 NAME 'dcObject'
+	DESC 'RFC2247: domain component object'
+	SUP top AUXILIARY MUST dc )
+
+# RFC 2377
+objectclass ( 1.3.6.1.1.3.1 NAME 'uidObject'
+	DESC 'RFC2377: uid object'
+	SUP top AUXILIARY MUST uid )
+
+# RFC 4524
+#   The 'associatedDomain' attribute specifies DNS [RFC1034][RFC2181]
+#   host names [RFC1123] that are associated with an object.   That is,
+#   values of this attribute should conform to the following ABNF:
+#
+#    domain = root / label *( DOT label )
+#    root   = SPACE
+#    label  = LETDIG [ *61( LETDIG / HYPHEN ) LETDIG ]
+#    LETDIG = %x30-39 / %x41-5A / %x61-7A ; "0" - "9" / "A"-"Z" / "a"-"z"
+#    SPACE  = %x20                        ; space (" ")
+#    HYPHEN = %x2D                        ; hyphen ("-")
+#    DOT    = %x2E                        ; period (".")
+attributetype ( 0.9.2342.19200300.100.1.37
+	NAME 'associatedDomain'
+	DESC 'RFC1274: domain associated with object'
+	EQUALITY caseIgnoreIA5Match
+	SUBSTR caseIgnoreIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# RFC 2459 -- deprecated in favor of 'mail' (in cosine.schema)
+attributetype ( 1.2.840.113549.1.9.1
+	NAME ( 'email' 'emailAddress' 'pkcs9email' )
+	DESC 'RFC3280: legacy attribute for email addresses in DNs'
+	EQUALITY caseIgnoreIA5Match
+	SUBSTR caseIgnoreIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+

--- a/scripts/docker/auth/openldap/schema/cosine.schema
+++ b/scripts/docker/auth/openldap/schema/cosine.schema
@@ -1,0 +1,2555 @@
+# RFC1274: Cosine and Internet X.500 schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# RFC1274: Cosine and Internet X.500 schema
+#
+# This file contains LDAPv3 schema derived from X.500 COSINE "pilot"
+# schema.  As this schema was defined for X.500(89), some
+# oddities were introduced in the mapping to LDAPv3.  The
+# mappings were based upon: draft-ietf-asid-ldapv3-attributes-03.txt
+# (a work in progress)
+#
+# Note: It seems that the pilot schema evolved beyond what was
+# described in RFC1274.  However, this document attempts to describes
+# RFC1274 as published.
+#
+# Depends on core.schema
+
+
+# Network Working Group                                          P. Barker
+# Request for Comments: 1274                                      S. Kille
+#                                              University College London
+#                                                          November 1991
+#
+#                 The COSINE and Internet X.500 Schema
+#
+# [trimmed]
+#
+# Abstract
+#
+#  This document suggests an X.500 Directory Schema, or Naming
+#  Architecture, for use in the COSINE and Internet X.500 pilots.  The
+#  schema is independent of any specific implementation.  As well as
+#  indicating support for the standard object classes and attributes, a
+#  large number of generally useful object classes and attributes are
+#  also defined.  An appendix to this document includes a machine
+#  processable version of the schema.
+#
+# [trimmed]
+
+# 7.  Object Identifiers
+#
+#  Some additional object identifiers are defined for this schema.
+#  These are also reproduced in Appendix C.
+#
+#    data OBJECT IDENTIFIER ::= {ccitt 9}
+#    pss OBJECT IDENTIFIER ::= {data 2342}
+#    ucl OBJECT IDENTIFIER ::= {pss 19200300}
+#    pilot OBJECT IDENTIFIER ::= {ucl 100}
+#
+#    pilotAttributeType OBJECT IDENTIFIER ::= {pilot 1}
+#    pilotAttributeSyntax OBJECT IDENTIFIER ::= {pilot 3}
+#    pilotObjectClass OBJECT IDENTIFIER ::= {pilot 4}
+#    pilotGroups OBJECT IDENTIFIER ::= {pilot 10}
+#
+#    iA5StringSyntax OBJECT IDENTIFIER ::= {pilotAttributeSyntax 4}
+#    caseIgnoreIA5StringSyntax OBJECT IDENTIFIER ::=
+#                                          {pilotAttributeSyntax 5}
+#
+# 8.  Object Classes
+# [relocated after 9]
+
+#
+# 9.  Attribute Types
+#
+# 9.1.  X.500 standard attribute types
+#
+#  A number of generally useful attribute types are defined in X.520,
+#  and these are supported.  Refer to that document for descriptions of
+#  the suggested usage of these attribute types.  The ASN.1 for these
+#  attribute types is reproduced for completeness in Appendix C.
+#
+# 9.2.  X.400 standard attribute types
+#
+#  The standard X.400 attribute types are supported.  See X.402 for full
+#  details.  The ASN.1 for these attribute types is reproduced in
+#  Appendix C.
+#
+# 9.3.  COSINE/Internet attribute types
+#
+#  This section describes all the attribute types defined for use in the
+#  COSINE and Internet pilots.  Descriptions are given as to the
+#  suggested usage of these attribute types.  The ASN.1 for these
+#  attribute types is reproduced in Appendix C.
+#
+# 9.3.1.  Userid
+#
+#  The Userid attribute type specifies a computer system login name.
+#
+#    userid ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-user-identifier))
+#    ::= {pilotAttributeType 1}
+#
+#(in core.schema)
+##attributetype ( 0.9.2342.19200300.100.1.1 NAME ( 'uid' 'userid' )
+##	EQUALITY caseIgnoreMatch
+##	SUBSTR caseIgnoreSubstringsMatch
+##	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.2.  Text Encoded O/R Address
+#
+#  The Text Encoded O/R Address attribute type specifies a text encoding
+#  of an X.400 O/R address, as specified in RFC 987.  The use of this
+#  attribute is deprecated as the attribute is intended for interim use
+#  only.  This attribute will be the first candidate for the attribute
+#  expiry mechanisms!
+#
+#    textEncodedORAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#        (SIZE (1 .. ub-text-encoded-or-address))
+#    ::= {pilotAttributeType 2}
+#
+attributetype ( 0.9.2342.19200300.100.1.2 NAME 'textEncodedORAddress'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.3.  RFC 822 Mailbox
+#
+#  The RFC822 Mailbox attribute type specifies an electronic mailbox
+#  attribute following the syntax specified in RFC 822.  Note that this
+#  attribute should not be used for greybook or other non-Internet order
+#  mailboxes.
+#
+#    rfc822Mailbox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#            (SIZE (1 .. ub-rfc822-mailbox))
+#    ::= {pilotAttributeType 3}
+#
+#(in core.schema)
+##attributetype ( 0.9.2342.19200300.100.1.3 NAME ( 'mail' 'rfc822Mailbox' )
+##	EQUALITY caseIgnoreIA5Match
+##	SUBSTR caseIgnoreIA5SubstringsMatch
+##	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+
+
+# 9.3.5.  Favourite Drink
+#
+#  The Favourite Drink attribute type specifies the favourite drink of
+#  an object (or person).
+#
+#    favouriteDrink ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-favourite-drink))
+#    ::= {pilotAttributeType 5}
+#
+attributetype ( 0.9.2342.19200300.100.1.5
+	NAME ( 'drink' 'favouriteDrink' )
+	DESC 'RFC1274: favorite drink'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.6.  Room Number
+#
+#  The Room Number attribute type specifies the room number of an
+#  object.  Note that the commonName attribute should be used for naming
+#  room objects.
+#
+#    roomNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-room-number))
+#    ::= {pilotAttributeType 6}
+#
+attributetype ( 0.9.2342.19200300.100.1.6 NAME 'roomNumber'
+	DESC 'RFC1274: room number'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.7.  Photo
+#
+#  The Photo attribute type specifies a "photograph" for an object.
+#  This should be encoded in G3 fax as explained in recommendation T.4,
+#  with an ASN.1 wrapper to make it compatible with an X.400 BodyPart as
+#  defined in X.420.
+#
+#    IMPORT  G3FacsimileBodyPart  FROM  {   mhs-motis   ipms   modules
+#    information-objects }
+#
+#    photo ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            CHOICE {
+#                g3-facsimile [3] G3FacsimileBodyPart
+#                }
+#        (SIZE (1 .. ub-photo))
+#    ::= {pilotAttributeType 7}
+#
+attributetype ( 0.9.2342.19200300.100.1.7 NAME 'photo'
+	DESC 'RFC1274: photo (G3 fax)'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.23{25000} )
+
+# 9.3.8.  User Class
+#
+#  The User Class attribute type specifies a category of computer user.
+#  The semantics placed on this attribute are for local interpretation.
+#  Examples of current usage od this attribute in academia are
+#  undergraduate student, researcher, lecturer, etc.  Note that the
+#  organizationalStatus attribute may now often be preferred as it makes
+#  no distinction between computer users and others.
+#
+#    userClass ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-user-class))
+#    ::= {pilotAttributeType 8}
+#
+attributetype ( 0.9.2342.19200300.100.1.8 NAME 'userClass'
+	DESC 'RFC1274: category of user'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.9.  Host
+#
+#  The Host attribute type specifies a host computer.
+#
+#    host ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-host))
+#    ::= {pilotAttributeType 9}
+#
+attributetype ( 0.9.2342.19200300.100.1.9 NAME 'host'
+	DESC 'RFC1274: host computer'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+## Moved to microsoftattributetypestd.schema to satisfy
+## organizationalPerson objectclass
+##
+## 9.3.10.  Manager
+##
+##  The Manager attribute type specifies the manager of an object
+##  represented by an entry.
+##
+##    manager ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            distinguishedNameSyntax
+##    ::= {pilotAttributeType 10}
+##
+#attributetype ( 0.9.2342.19200300.100.1.10 NAME 'manager'
+#	DESC 'RFC1274: DN of manager'
+#	EQUALITY distinguishedNameMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+# 9.3.11.  Document Identifier
+#
+#  The Document Identifier attribute type specifies a unique identifier
+#  for a document.
+#
+#    documentIdentifier ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-document-identifier))
+#    ::= {pilotAttributeType 11}
+#
+attributetype ( 0.9.2342.19200300.100.1.11 NAME 'documentIdentifier'
+	DESC 'RFC1274: unique identifier of document'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.12.  Document Title
+#
+#  The Document Title attribute type specifies the title of a document.
+#
+#    documentTitle ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#        (SIZE (1 .. ub-document-title))
+#    ::= {pilotAttributeType 12}
+#
+attributetype ( 0.9.2342.19200300.100.1.12 NAME 'documentTitle'
+	DESC 'RFC1274: title of document'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.13.  Document Version
+#
+#  The Document Version attribute type specifies the version number of a
+#  document.
+#
+#    documentVersion ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-document-version))
+#    ::= {pilotAttributeType 13}
+#
+attributetype ( 0.9.2342.19200300.100.1.13 NAME 'documentVersion'
+	DESC 'RFC1274: version of document'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.14.  Document Author
+#
+#  The Document Author attribute type specifies the distinguished name
+#  of the author of a document.
+#
+#    documentAuthor ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 14}
+#
+attributetype ( 0.9.2342.19200300.100.1.14 NAME 'documentAuthor'
+	DESC 'RFC1274: DN of author of document'
+	EQUALITY distinguishedNameMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+# 9.3.15.  Document Location
+#
+#  The Document Location attribute type specifies the location of the
+#  document original.
+#
+#    documentLocation ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-document-location))
+#    ::= {pilotAttributeType 15}
+#
+attributetype ( 0.9.2342.19200300.100.1.15 NAME 'documentLocation'
+	DESC 'RFC1274: location of document original'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+## Moved to microsoftattributetypestd.schema to satisfy
+## organizationalPerson objectclass
+##
+## 9.3.16.  Home Telephone Number
+##
+##  The Home Telephone Number attribute type specifies a home telephone
+##  number associated with a person.  Attribute values should follow the
+##  agreed format for international telephone numbers: i.e., "+44 71 123
+##  4567".
+##
+##    homeTelephoneNumber ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            telephoneNumberSyntax
+##    ::= {pilotAttributeType 20}
+##
+#attributetype ( 0.9.2342.19200300.100.1.20
+#	NAME ( 'homePhone' 'homeTelephoneNumber' )
+#	DESC 'RFC1274: home telephone number'
+#	EQUALITY telephoneNumberMatch
+#	SUBSTR telephoneNumberSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50 )
+
+# 9.3.17.  Secretary
+#
+#  The Secretary attribute type specifies the secretary of a person.
+#  The attribute value for Secretary is a distinguished name.
+#
+#    secretary ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 21}
+#
+attributetype ( 0.9.2342.19200300.100.1.21 NAME 'secretary'
+	DESC 'RFC1274: DN of secretary'
+	EQUALITY distinguishedNameMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+## Moved to microsoftattributetype.schema to satisfy
+## organizationalPerson objectclass
+##
+## 9.3.18.  Other Mailbox
+##
+##  The Other Mailbox attribute type specifies values for electronic
+##  mailbox types other than X.400 and rfc822.
+##
+##    otherMailbox ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            SEQUENCE {
+##                    mailboxType PrintableString, -- e.g. Telemail
+##                    mailbox IA5String  -- e.g. X378:Joe
+##            }
+##    ::= {pilotAttributeType 22}
+##
+#attributetype ( 0.9.2342.19200300.100.1.22 NAME 'otherMailbox'
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.39 )
+
+# 9.3.19.  Last Modified Time
+#
+#  The Last Modified Time attribute type specifies the last time, in UTC
+#  time, that an entry was modified.  Ideally, this attribute should be
+#  maintained by the DSA.
+#
+#    lastModifiedTime ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            uTCTimeSyntax
+#    ::= {pilotAttributeType 23}
+#
+## Deprecated in favor of modifyTimeStamp
+#attributetype ( 0.9.2342.19200300.100.1.23 NAME 'lastModifiedTime'
+#	DESC 'RFC1274: time of last modify, replaced by modifyTimestamp'
+#	OBSOLETE
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.53
+#	USAGE directoryOperation )
+
+# 9.3.20.  Last Modified By
+#
+#  The Last Modified By attribute specifies the distinguished name of
+#  the last user to modify the associated entry.  Ideally, this
+#  attribute should be maintained by the DSA.
+#
+#    lastModifiedBy ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 24}
+#
+## Deprecated in favor of modifiersName
+#attributetype ( 0.9.2342.19200300.100.1.24 NAME 'lastModifiedBy'
+#	DESC 'RFC1274: last modifier, replaced by modifiersName'
+#	OBSOLETE
+#	EQUALITY distinguishedNameMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+#	USAGE directoryOperation )
+
+# 9.3.21.  Domain Component
+#
+#  The Domain Component attribute type specifies a DNS/NRS domain.  For
+#  example, "uk" or "ac".
+#
+#    domainComponent ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#            SINGLE VALUE
+#    ::= {pilotAttributeType 25}
+#
+##(in core.schema)
+##attributetype ( 0.9.2342.19200300.100.1.25 NAME ( 'dc' 'domainComponent' )
+##	EQUALITY caseIgnoreIA5Match
+##	SUBSTR caseIgnoreIA5SubstringsMatch
+##	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+# 9.3.22.  DNS ARecord
+#
+#  The A Record attribute type specifies a type A (Address) DNS resource
+#  record [6] [7].
+#
+#    aRecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 26}
+#
+## incorrect syntax?
+attributetype ( 0.9.2342.19200300.100.1.26 NAME 'aRecord'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+## missing from RFC1274
+## incorrect syntax?
+attributetype ( 0.9.2342.19200300.100.1.27 NAME 'mDRecord'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 9.3.23.  MX Record
+#
+#  The MX Record attribute type specifies a type MX (Mail Exchange) DNS
+#  resource record [6] [7].
+#
+#    mXRecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 28}
+#
+## incorrect syntax!!
+attributetype ( 0.9.2342.19200300.100.1.28 NAME 'mXRecord'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 9.3.24.  NS Record
+#
+#  The NS Record attribute type specifies an NS (Name Server) DNS
+#  resource record [6] [7].
+#
+#    nSRecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 29}
+#
+## incorrect syntax!!
+attributetype ( 0.9.2342.19200300.100.1.29 NAME 'nSRecord'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 9.3.25.  SOA Record
+#
+#  The SOA Record attribute type specifies a type SOA (Start of
+#  Authority) DNS resorce record [6] [7].
+#
+#    sOARecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 30}
+#
+## incorrect syntax!!
+attributetype ( 0.9.2342.19200300.100.1.30 NAME 'sOARecord'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 9.3.26.  CNAME Record
+#
+#  The CNAME Record attribute type specifies a type CNAME (Canonical
+#  Name) DNS resource record [6] [7].
+#
+#    cNAMERecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            iA5StringSyntax
+#    ::= {pilotAttributeType 31}
+#
+## incorrect syntax!!
+attributetype ( 0.9.2342.19200300.100.1.31 NAME 'cNAMERecord'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 9.3.27.  Associated Domain
+#
+#  The Associated Domain attribute type specifies a DNS or NRS domain
+#  which is associated with an object in the DIT. For example, the entry
+#  in the DIT with a distinguished name "C=GB, O=University College
+#  London" would have an associated domain of "UCL.AC.UK.  Note that all
+#  domains should be represented in rfc822 order.  See [3] for more
+#  details of usage of this attribute.
+#
+#    associatedDomain ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#    ::= {pilotAttributeType 37}
+#
+#attributetype ( 0.9.2342.19200300.100.1.37 NAME 'associatedDomain'
+#	EQUALITY caseIgnoreIA5Match
+#	SUBSTR caseIgnoreIA5SubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 9.3.28.  Associated Name
+#
+#  The Associated Name attribute type specifies an entry in the
+#  organisational DIT associated with a DNS/NRS domain.  See [3] for
+#  more details of usage of this attribute.
+#
+#    associatedName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 38}
+#
+attributetype ( 0.9.2342.19200300.100.1.38 NAME 'associatedName'
+	DESC 'RFC1274: DN of entry associated with domain'
+	EQUALITY distinguishedNameMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+## Moved to microsoftattributetype.schema to satisfy
+## organizationalPerson objectclass
+##
+## 9.3.29.  Home postal address
+##
+##  The Home postal address attribute type specifies a home postal
+##  address for an object.  This should be limited to up to 6 lines of 30
+##  characters each.
+##
+##    homePostalAddress ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            postalAddress
+##            MATCHES FOR EQUALITY
+##    ::= {pilotAttributeType 39}
+##
+#attributetype ( 0.9.2342.19200300.100.1.39 NAME 'homePostalAddress'
+#	DESC 'RFC1274: home postal address'
+#	EQUALITY caseIgnoreListMatch
+#	SUBSTR caseIgnoreListSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+
+# Moved to microsoftattributetype.schema to satisfy
+# organizationalPerson objectclass
+#
+## 9.3.30.  Personal Title
+##
+##  The Personal Title attribute type specifies a personal title for a
+##  person. Examples of personal titles are "Ms", "Dr", "Prof" and "Rev".
+##
+##    personalTitle ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            caseIgnoreStringSyntax
+##            (SIZE (1 .. ub-personal-title))
+##    ::= {pilotAttributeType 40}
+##
+#attributetype ( 0.9.2342.19200300.100.1.40 NAME 'personalTitle'
+#	DESC 'RFC1274: personal title'
+#	EQUALITY caseIgnoreMatch
+#	SUBSTR caseIgnoreSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+## Moved to microsoftattributetypestd.schema to satisfy
+## organizationalPerson objectclass
+##
+## 9.3.31.  Mobile Telephone Number
+##
+##  The Mobile Telephone Number attribute type specifies a mobile
+##  telephone number associated with a person.  Attribute values should
+##  follow the agreed format for international telephone numbers: i.e.,
+##  "+44 71 123 4567".
+##
+##    mobileTelephoneNumber ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            telephoneNumberSyntax
+##    ::= {pilotAttributeType 41}
+##
+#attributetype ( 0.9.2342.19200300.100.1.41
+#	NAME ( 'mobile' 'mobileTelephoneNumber' )
+#	DESC 'RFC1274: mobile telephone number'
+#	EQUALITY telephoneNumberMatch
+#	SUBSTR telephoneNumberSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50 )
+
+## Moved to microsoftattributetypestd.schema to satisfy
+## organizationalPerson objectclass
+##
+## 9.3.32.  Pager Telephone Number
+##
+##  The Pager Telephone Number attribute type specifies a pager telephone
+##  number for an object. Attribute values should follow the agreed
+##  format for international telephone numbers: i.e., "+44 71 123 4567".
+##
+##    pagerTelephoneNumber ATTRIBUTE
+##        WITH ATTRIBUTE-SYNTAX
+##            telephoneNumberSyntax
+##    ::= {pilotAttributeType 42}
+##
+#attributetype ( 0.9.2342.19200300.100.1.42
+#	NAME ( 'pager' 'pagerTelephoneNumber' )
+#	DESC 'RFC1274: pager telephone number'
+#	EQUALITY telephoneNumberMatch
+#	SUBSTR telephoneNumberSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50 )
+
+# 9.3.34.  Unique Identifier
+#
+#  The Unique Identifier attribute type specifies a "unique identifier"
+#  for an object represented in the Directory.  The domain within which
+#  the identifier is unique, and the exact semantics of the identifier,
+#  are for local definition.  For a person, this might be an
+#  institution-wide payroll number.  For an organisational unit, it
+#  might be a department code.
+#
+#    uniqueIdentifier ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-unique-identifier))
+#    ::= {pilotAttributeType 44}
+#
+attributetype ( 0.9.2342.19200300.100.1.44 NAME 'uniqueIdentifier'
+	DESC 'RFC1274: unique identifer'
+	EQUALITY caseIgnoreMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.35.  Organisational Status
+#
+#  The Organisational Status attribute type specifies a category by
+#  which a person is often referred to in an organisation.  Examples of
+#  usage in academia might include undergraduate student, researcher,
+#  lecturer, etc.
+#
+#  A Directory administrator should probably consider carefully the
+#  distinctions between this and the title and userClass attributes.
+#
+#    organizationalStatus ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-organizational-status))
+#    ::= {pilotAttributeType 45}
+#
+attributetype ( 0.9.2342.19200300.100.1.45 NAME 'organizationalStatus'
+	DESC 'RFC1274: organizational status'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.36.  Janet Mailbox
+#
+#  The Janet Mailbox attribute type specifies an electronic mailbox
+#  attribute following the syntax specified in the Grey Book of the
+#  Coloured Book series.  This attribute is intended for the convenience
+#  of U.K users unfamiliar with rfc822 and little-endian mail addresses.
+#  Entries using this attribute MUST also include an rfc822Mailbox
+#  attribute.
+#
+#    janetMailbox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#            (SIZE (1 .. ub-janet-mailbox))
+#    ::= {pilotAttributeType 46}
+#
+attributetype ( 0.9.2342.19200300.100.1.46 NAME 'janetMailbox'
+	DESC 'RFC1274: Janet mailbox'
+	EQUALITY caseIgnoreIA5Match
+	SUBSTR caseIgnoreIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+
+# 9.3.37.  Mail Preference Option
+#
+#  An attribute to allow users to indicate a preference for inclusion of
+#  their names on mailing lists (electronic or physical).  The absence
+#  of such an attribute should be interpreted as if the attribute was
+#  present with value "no-list-inclusion".  This attribute should be
+#  interpreted by anyone using the directory to derive mailing lists,
+#  and its value respected.
+#
+#    mailPreferenceOption ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX ENUMERATED {
+#                no-list-inclusion(0),
+#                any-list-inclusion(1),  -- may be added to any lists
+#                professional-list-inclusion(2)
+#                                        -- may be added to lists
+#                                        -- which the list provider
+#                                        -- views as related to the
+#                                        -- users professional inter-
+#                                        -- ests, perhaps evaluated
+#                                        -- from the business of the
+#                                        -- organisation or keywords
+#                                        -- in the entry.
+#                }
+#    ::= {pilotAttributeType 47}
+#
+attributetype ( 0.9.2342.19200300.100.1.47
+	NAME 'mailPreferenceOption'
+	DESC 'RFC1274: mail preference option'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+
+# 9.3.38.  Building Name
+#
+#  The Building Name attribute type specifies the name of the building
+#  where an organisation or organisational unit is based.
+#
+#    buildingName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-building-name))
+#    ::= {pilotAttributeType 48}
+#
+attributetype ( 0.9.2342.19200300.100.1.48 NAME 'buildingName'
+	DESC 'RFC1274: name of building'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+# 9.3.39.  DSA Quality
+#
+#  The DSA Quality attribute type specifies the purported quality of a
+#  DSA.  It allows a DSA manager to indicate the expected level of
+#  availability of the DSA. See [8] for details of the syntax.
+#
+#    dSAQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DSAQualitySyntax
+#            SINGLE VALUE
+#    ::= {pilotAttributeType 49}
+#
+attributetype ( 0.9.2342.19200300.100.1.49 NAME 'dSAQuality'
+	DESC 'RFC1274: DSA Quality'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.19 SINGLE-VALUE )
+
+# 9.3.40.  Single Level Quality
+#
+#  The Single Level Quality attribute type specifies the purported data
+#  quality at the level immediately below in the DIT.  See [8] for
+#  details of the syntax.
+#
+#    singleLevelQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DataQualitySyntax
+#            SINGLE VALUE
+#    ::= {pilotAttributeType 50}
+#
+attributetype ( 0.9.2342.19200300.100.1.50 NAME 'singleLevelQuality'
+	DESC 'RFC1274: Single Level Quality'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.13 SINGLE-VALUE )
+
+# 9.3.41.  Subtree Minimum Quality
+#
+#  The Subtree Minimum Quality attribute type specifies the purported
+#  minimum data quality for a DIT subtree.  See [8] for more discussion
+#  and details of the syntax.
+#
+#    subtreeMinimumQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DataQualitySyntax
+#            SINGLE VALUE
+#               -- Defaults to singleLevelQuality
+#    ::= {pilotAttributeType 51}
+#
+attributetype ( 0.9.2342.19200300.100.1.51 NAME 'subtreeMinimumQuality'
+	DESC 'RFC1274: Subtree Mininum Quality'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.13 SINGLE-VALUE )
+
+# 9.3.42.  Subtree Maximum Quality
+#
+#  The Subtree Maximum Quality attribute type specifies the purported
+#  maximum data quality for a DIT subtree.  See [8] for more discussion
+#  and details of the syntax.
+#
+#    subtreeMaximumQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DataQualitySyntax
+#            SINGLE VALUE
+#               -- Defaults to singleLevelQuality
+#    ::= {pilotAttributeType 52}
+#
+attributetype ( 0.9.2342.19200300.100.1.52 NAME 'subtreeMaximumQuality'
+	DESC 'RFC1274: Subtree Maximun Quality'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.13 SINGLE-VALUE )
+
+# 9.3.43.  Personal Signature
+#
+#  The Personal Signature attribute type allows for a representation of
+#  a person's signature.  This should be encoded in G3 fax as explained
+#  in recommendation T.4, with an ASN.1 wrapper to make it compatible
+#  with an X.400 BodyPart as defined in X.420.
+#
+#    IMPORT  G3FacsimileBodyPart  FROM  {   mhs-motis   ipms   modules
+#    information-objects }
+#
+#    personalSignature ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            CHOICE {
+#                g3-facsimile [3] G3FacsimileBodyPart
+#                }
+#        (SIZE (1 .. ub-personal-signature))
+#    ::= {pilotAttributeType 53}
+#
+attributetype ( 0.9.2342.19200300.100.1.53 NAME 'personalSignature'
+	DESC 'RFC1274: Personal Signature (G3 fax)'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.23 )
+
+# 9.3.44.  DIT Redirect
+#
+#  The DIT Redirect attribute type is used to indicate that the object
+#  described by one entry now has a newer entry in the DIT.  The entry
+#  containing the redirection attribute should be expired after a
+#  suitable grace period.  This attribute may be used when an individual
+#  changes his/her place of work, and thus acquires a new organisational
+#  DN.
+#
+#    dITRedirect ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 54}
+#
+attributetype ( 0.9.2342.19200300.100.1.54 NAME 'dITRedirect'
+	DESC 'RFC1274: DIT Redirect'
+	EQUALITY distinguishedNameMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+# 9.3.45.  Audio
+#
+#  The Audio attribute type allows the storing of sounds in the
+#  Directory.  The attribute uses a u-law encoded sound file as used by
+#  the "play" utility on a Sun 4.  This is an interim format.
+#
+#    audio ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            Audio
+#        (SIZE (1 .. ub-audio))
+#    ::= {pilotAttributeType 55}
+#
+attributetype ( 0.9.2342.19200300.100.1.55 NAME 'audio'
+	DESC 'RFC1274: audio (u-law)'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.4{25000} )
+
+# 9.3.46.  Publisher of Document
+#
+#
+#  The Publisher of Document attribute is the person and/or organization
+#  that published a document.
+#
+#    documentPublisher ATTRIBUTE
+#            WITH ATTRIBUTE SYNTAX caseIgnoreStringSyntax
+#    ::= {pilotAttributeType 56}
+#
+attributetype ( 0.9.2342.19200300.100.1.56 NAME 'documentPublisher'
+	DESC 'RFC1274: publisher of document'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# 9.4.  Generally useful syntaxes
+#
+#    caseIgnoreIA5StringSyntax ATTRIBUTE-SYNTAX
+#            IA5String
+#            MATCHES FOR EQUALITY SUBSTRINGS
+#
+#    iA5StringSyntax ATTRIBUTE-SYNTAX
+#        IA5String
+#        MATCHES FOR EQUALITY SUBSTRINGS
+#
+#
+#    -- Syntaxes to support the DNS attributes
+#
+#    DNSRecordSyntax ATTRIBUTE-SYNTAX
+#            IA5String
+#            MATCHES FOR EQUALITY
+#
+#
+#    NRSInformationSyntax ATTRIBUTE-SYNTAX
+#            NRSInformation
+#            MATCHES FOR EQUALITY
+#
+#
+#    NRSInformation ::=  SET {
+#                    [0] Context,
+#                    [1] Address-space-id,
+#                    routes [2] SEQUENCE OF SEQUENCE {
+#                    Route-cost,
+#                    Addressing-info }
+#            }
+#
+#
+# 9.5.  Upper bounds on length of attribute values
+#
+#
+#    ub-document-identifier INTEGER ::= 256
+#
+#    ub-document-location INTEGER ::= 256
+#
+#    ub-document-title INTEGER ::= 256
+#
+#    ub-document-version INTEGER ::= 256
+#
+#    ub-favourite-drink INTEGER ::= 256
+#
+#    ub-host INTEGER ::= 256
+#
+#    ub-information INTEGER ::= 2048
+#
+#    ub-unique-identifier INTEGER ::= 256
+#
+#    ub-personal-title INTEGER ::= 256
+#
+#    ub-photo INTEGER ::= 250000
+#
+#    ub-rfc822-mailbox INTEGER ::= 256
+#
+#    ub-room-number INTEGER ::= 256
+#
+#    ub-text-or-address INTEGER ::= 256
+#
+#    ub-user-class INTEGER ::= 256
+#
+#    ub-user-identifier INTEGER ::= 256
+#
+#    ub-organizational-status INTEGER ::= 256
+#
+#    ub-janet-mailbox INTEGER ::= 256
+#
+#    ub-building-name INTEGER ::= 256
+#
+#    ub-personal-signature ::= 50000
+#
+#    ub-audio INTEGER ::= 250000
+#
+
+# [back to 8]
+# 8.  Object Classes
+#
+# 8.1.  X.500 standard object classes
+#
+#  A number of generally useful object classes are defined in X.521, and
+#  these are supported.  Refer to that document for descriptions of the
+#  suggested usage of these object classes.  The ASN.1 for these object
+#  classes is reproduced for completeness in Appendix C.
+#
+# 8.2.  X.400 standard object classes
+#
+#  A number of object classes defined in X.400 are supported.  Refer to
+#  X.402 for descriptions of the usage of these object classes.  The
+#  ASN.1 for these object classes is reproduced for completeness in
+#  Appendix C.
+#
+# 8.3.  COSINE/Internet object classes
+#
+#  This section attempts to fuse together the object classes designed
+#  for use in the COSINE and Internet pilot activities.  Descriptions
+#  are given of the suggested usage of these object classes.  The ASN.1
+#  for these object classes is also reproduced in Appendix C.
+#
+# 8.3.1.  Pilot Object
+#
+#  The PilotObject object class is used as a sub-class to allow some
+#  common, useful attributes to be assigned to entries of all other
+#  object classes.
+#
+#    pilotObject OBJECT-CLASS
+#        SUBCLASS OF top
+#        MAY CONTAIN {
+#            info,
+#            photo,
+#            manager,
+#            uniqueIdentifier,
+#            lastModifiedTime,
+#            lastModifiedBy,
+#            dITRedirect,
+#            audio}
+#    ::= {pilotObjectClass 3}
+#
+#objectclass ( 0.9.2342.19200300.100.4.3 NAME 'pilotObject'
+#	DESC 'RFC1274: pilot object'
+#	SUP top AUXILIARY
+#	MAY ( info $ photo $ manager $ uniqueIdentifier $
+#		lastModifiedTime $ lastModifiedBy $ dITRedirect $ audio )
+#	)
+
+# 8.3.2.  Pilot Person
+#
+#  The PilotPerson object class is used as a sub-class of person, to
+#  allow the use of a number of additional attributes to be assigned to
+#  entries of object class person.
+#
+#    pilotPerson OBJECT-CLASS
+#        SUBCLASS OF person
+#        MAY CONTAIN {
+#                    userid,
+#                    textEncodedORAddress,
+#                    rfc822Mailbox,
+#                    favouriteDrink,
+#                    roomNumber,
+#                    userClass,
+#                    homeTelephoneNumber,
+#                    homePostalAddress,
+#                    secretary,
+#                    personalTitle,
+#                    preferredDeliveryMethod,
+#                    businessCategory,
+#                    janetMailbox,
+#                    otherMailbox,
+#                    mobileTelephoneNumber,
+#                    pagerTelephoneNumber,
+#                    organizationalStatus,
+#                    mailPreferenceOption,
+#                    personalSignature}
+#    ::= {pilotObjectClass 4}
+#
+objectclass ( 0.9.2342.19200300.100.4.4
+	NAME ( 'pilotPerson' 'newPilotPerson' )
+	SUP person STRUCTURAL
+	MAY ( userid $ textEncodedORAddress $ rfc822Mailbox $
+		favouriteDrink $ roomNumber $ userClass $
+		homeTelephoneNumber $ homePostalAddress $ secretary $
+		personalTitle $ preferredDeliveryMethod $ businessCategory $
+		janetMailbox $ otherMailbox $ mobileTelephoneNumber $
+		pagerTelephoneNumber $ organizationalStatus $
+		mailPreferenceOption $ personalSignature )
+	)
+
+# 8.3.3.  Account
+#
+#  The Account object class is used to define entries representing
+#  computer accounts.  The userid attribute should be used for naming
+#  entries of this object class.
+#
+#    account OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            userid}
+#        MAY CONTAIN {
+#            description,
+#            seeAlso,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName,
+#            host}
+#    ::= {pilotObjectClass 5}
+#
+objectclass ( 0.9.2342.19200300.100.4.5 NAME 'account'
+	SUP top STRUCTURAL
+	MUST userid
+	MAY ( description $ seeAlso $ localityName $
+		organizationName $ organizationalUnitName $ host )
+	)
+
+# 8.3.4.  Document
+#
+#  The Document object class is used to define entries which represent
+#  documents.
+#
+#    document OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            documentIdentifier}
+#        MAY CONTAIN {
+#            commonName,
+#            description,
+#            seeAlso,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName,
+#            documentTitle,
+#            documentVersion,
+#            documentAuthor,
+#            documentLocation,
+#            documentPublisher}
+#    ::= {pilotObjectClass 6}
+#
+objectclass ( 0.9.2342.19200300.100.4.6 NAME 'document'
+	SUP top STRUCTURAL
+	MUST documentIdentifier
+	MAY ( commonName $ description $ seeAlso $ localityName $
+		organizationName $ organizationalUnitName $
+		documentTitle $ documentVersion $ documentAuthor $
+		documentLocation $ documentPublisher )
+	)
+
+# 8.3.5.  Room
+#
+#  The Room object class is used to define entries representing rooms.
+#  The commonName attribute should be used for naming pentries of this
+#  object class.
+#
+#    room OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            roomNumber,
+#            description,
+#            seeAlso,
+#            telephoneNumber}
+#    ::= {pilotObjectClass 7}
+#
+objectclass ( 0.9.2342.19200300.100.4.7 NAME 'room'
+	SUP top STRUCTURAL
+	MUST commonName
+	MAY ( roomNumber $ description $ seeAlso $ telephoneNumber )
+	)
+
+# 8.3.6.  Document Series
+#
+#  The Document Series object class is used to define an entry which
+#  represents a series of documents (e.g., The Request For Comments
+#  papers).
+#
+#    documentSeries OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            description,
+#            seeAlso,
+#            telephoneNumber,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName}
+#    ::= {pilotObjectClass 9}
+#
+objectclass ( 0.9.2342.19200300.100.4.9 NAME 'documentSeries'
+	SUP top STRUCTURAL
+	MUST commonName
+	MAY ( description $ seeAlso $ telephonenumber $
+		localityName $ organizationName $ organizationalUnitName )
+	)
+
+# 8.3.7.  Domain
+#
+#  The Domain object class is used to define entries which represent DNS
+#  or NRS domains.  The domainComponent attribute should be used for
+#  naming entries of this object class.  The usage of this object class
+#  is described in more detail in [3].
+#
+#    domain OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            domainComponent}
+#        MAY CONTAIN {
+#            associatedName,
+#            organizationName,
+#            organizationalAttributeSet}
+#    ::= {pilotObjectClass 13}
+#
+objectclass ( 0.9.2342.19200300.100.4.13 NAME 'domain'
+	SUP top STRUCTURAL
+	MUST dc
+	MAY ( domainComponent $ associatedName $ organizationName $ description $
+		businessCategory $ seeAlso $ searchGuide $ userPassword $
+		localityName $ stateOrProvinceName $ streetAddress $
+		physicalDeliveryOfficeName $ postalAddress $ postalCode $
+		postOfficeBox $ streetAddress $
+		facsimileTelephoneNumber $ internationalISDNNumber $
+		telephoneNumber $ teletexTerminalIdentifier $ telexNumber $
+		preferredDeliveryMethod $ destinationIndicator $
+		registeredAddress $ x121Address )
+	)
+
+# 8.3.8.  RFC822 Local Part
+#
+#  The RFC822 Local Part object class is used to define entries which
+#  represent the local part of RFC822 mail addresses.  This treats this
+#  part of an RFC822 address as a domain.  The usage of this object
+#  class is described in more detail in [3].
+#
+#    rFC822localPart OBJECT-CLASS
+#        SUBCLASS OF domain
+#        MAY CONTAIN {
+#            commonName,
+#            surname,
+#            description,
+#            seeAlso,
+#            telephoneNumber,
+#            postalAttributeSet,
+#            telecommunicationAttributeSet}
+#    ::= {pilotObjectClass 14}
+#
+objectclass ( 0.9.2342.19200300.100.4.14 NAME 'RFC822localPart'
+	SUP domain STRUCTURAL
+	MAY ( commonName $ surname $ description $ seeAlso $ telephoneNumber $
+		physicalDeliveryOfficeName $ postalAddress $ postalCode $
+		postOfficeBox $ streetAddress $
+		facsimileTelephoneNumber $ internationalISDNNumber $
+		telephoneNumber $ teletexTerminalIdentifier $
+		telexNumber $ preferredDeliveryMethod $ destinationIndicator $
+		registeredAddress $ x121Address )
+	)
+
+# 8.3.9.  DNS Domain
+#
+#  The DNS Domain (Domain NameServer) object class is used to define
+#  entries for DNS domains.  The usage of this object class is described
+#  in more detail in [3].
+#
+#    dNSDomain OBJECT-CLASS
+#        SUBCLASS OF domain
+#        MAY CONTAIN {
+#            ARecord,
+#            MDRecord,
+#            MXRecord,
+#            NSRecord,
+#            SOARecord,
+#            CNAMERecord}
+#    ::= {pilotObjectClass 15}
+#
+objectclass ( 0.9.2342.19200300.100.4.15 NAME 'dNSDomain'
+	SUP domain STRUCTURAL
+	MAY ( ARecord $ MDRecord $ MXRecord $ NSRecord $
+		SOARecord $ CNAMERecord )
+	)
+
+# 8.3.10.  Domain Related Object
+#
+#  The Domain Related Object object class is used to define entries
+#  which represent DNS/NRS domains which are "equivalent" to an X.500
+#  domain: e.g., an organisation or organisational unit.  The usage of
+#  this object class is described in more detail in [3].
+#
+#    domainRelatedObject OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            associatedDomain}
+#    ::= {pilotObjectClass 17}
+#
+objectclass ( 0.9.2342.19200300.100.4.17 NAME 'domainRelatedObject'
+	DESC 'RFC1274: an object related to an domain'
+	SUP top AUXILIARY
+	MUST associatedDomain )
+
+# 8.3.11.  Friendly Country
+#
+#  The Friendly Country object class is used to define country entries
+#  in the DIT.  The object class is used to allow friendlier naming of
+#  countries than that allowed by the object class country.  The naming
+#  attribute of object class country, countryName, has to be a 2 letter
+#  string defined in ISO 3166.
+#
+#    friendlyCountry OBJECT-CLASS
+#        SUBCLASS OF country
+#        MUST CONTAIN {
+#            friendlyCountryName}
+#    ::= {pilotObjectClass 18}
+#
+objectclass ( 0.9.2342.19200300.100.4.18 NAME 'friendlyCountry'
+	SUP country STRUCTURAL
+	MUST friendlyCountryName )
+
+# 8.3.12.  Simple Security Object
+#
+#  The Simple Security Object object class is used to allow an entry to
+#  have a userPassword attribute when an entry's principal object
+#  classes do not allow userPassword as an attribute type.
+#
+#    simpleSecurityObject OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            userPassword }
+#    ::= {pilotObjectClass 19}
+#
+## (in core.schema)
+## objectclass ( 0.9.2342.19200300.100.4.19 NAME 'simpleSecurityObject'
+##	SUP top AUXILIARY
+##	MUST userPassword )
+
+# 8.3.13.  Pilot Organization
+#
+#  The PilotOrganization object class is used as a sub-class of
+#  organization and organizationalUnit to allow a number of additional
+#  attributes to be assigned to entries of object classes organization
+#  and organizationalUnit.
+#
+#    pilotOrganization OBJECT-CLASS
+#        SUBCLASS OF organization, organizationalUnit
+#        MAY CONTAIN {
+#                    buildingName}
+#    ::= {pilotObjectClass 20}
+#
+objectclass ( 0.9.2342.19200300.100.4.20 NAME 'pilotOrganization'
+	SUP ( organization $ organizationalUnit ) STRUCTURAL
+	MAY buildingName )
+
+# 8.3.14.  Pilot DSA
+#
+#  The PilotDSA object class is used as a sub-class of the dsa object
+#  class to allow additional attributes to be assigned to entries for
+#  DSAs.
+#
+#    pilotDSA OBJECT-CLASS
+#        SUBCLASS OF dsa
+#        MUST CONTAIN {
+#            dSAQuality}
+#    ::= {pilotObjectClass 21}
+#
+objectclass ( 0.9.2342.19200300.100.4.21 NAME 'pilotDSA'
+	SUP dsa STRUCTURAL
+	MAY dSAQuality )
+
+# 8.3.15.  Quality Labelled Data
+#
+#  The Quality Labelled Data object class is used to allow the
+#  assignment of the data quality attributes to subtrees in the DIT.
+#
+#  See [8] for more details.
+#
+#    qualityLabelledData OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            dSAQuality}
+#        MAY CONTAIN {
+#            subtreeMinimumQuality,
+#            subtreeMaximumQuality}
+#    ::= {pilotObjectClass 22}
+objectclass ( 0.9.2342.19200300.100.4.22 NAME 'qualityLabelledData'
+	SUP top AUXILIARY
+	MUST dsaQuality
+	MAY ( subtreeMinimumQuality $ subtreeMaximumQuality )
+	)
+
+
+# References
+#
+#    [1]  CCITT/ISO, "X.500, The Directory - overview of concepts,
+#         models and services, CCITT /ISO IS 9594.
+#
+#    [2]  Kille, S., "The THORN and RARE X.500 Naming Architecture, in
+#         University College London, Department of Computer Science
+#         Research Note 89/48, May 1989.
+#
+#    [3]  Kille, S., "X.500 and Domains", RFC 1279, University College
+#         London, November 1991.
+#
+#    [4]  Rose, M., "PSI/NYSERNet White Pages Pilot Project: Status
+#         Report", Technical Report 90-09-10-1, published by NYSERNet
+#         Inc, 1990.
+#
+#    [5]  Craigie, J., "UK Academic Community Directory Service Pilot
+#         Project, pp. 305-310 in Computer Networks and ISDN Systems
+#         17 (1989), published by North Holland.
+#
+#    [6]  Mockapetris, P., "Domain Names - Concepts and Facilities",
+#         RFC 1034, USC/Information Sciences Institute, November 1987.
+#
+#    [7]  Mockapetris, P., "Domain Names - Implementation and
+#         Specification, RFC 1035, USC/Information Sciences Institute,
+#         November 1987.
+#
+#    [8]  Kille, S., "Handling QOS (Quality of service) in the
+#         Directory," publication in process, March 1991.
+#
+#
+# APPENDIX C - Summary of all Object Classes and Attribute Types
+#
+#    -- Some Important Object Identifiers
+#
+#    data OBJECT IDENTIFIER ::= {ccitt 9}
+#    pss OBJECT IDENTIFIER ::= {data 2342}
+#    ucl OBJECT IDENTIFIER ::= {pss 19200300}
+#    pilot OBJECT IDENTIFIER ::= {ucl 100}
+#
+#    pilotAttributeType OBJECT IDENTIFIER ::= {pilot 1}
+#    pilotAttributeSyntax OBJECT IDENTIFIER ::= {pilot 3}
+#    pilotObjectClass OBJECT IDENTIFIER ::= {pilot 4}
+#    pilotGroups OBJECT IDENTIFIER ::= {pilot 10}
+#
+#    iA5StringSyntax OBJECT IDENTIFIER ::= {pilotAttributeSyntax 4}
+#    caseIgnoreIA5StringSyntax OBJECT IDENTIFIER ::=
+#                                          {pilotAttributeSyntax 5}
+#
+#    -- Standard Object Classes
+#
+#    top OBJECT-CLASS
+#        MUST CONTAIN {
+#            objectClass}
+#    ::= {objectClass 0}
+#
+#
+#    alias OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            aliasedObjectName}
+#    ::= {objectClass 1}
+#
+#
+#    country OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            countryName}
+#        MAY CONTAIN {
+#            description,
+#            searchGuide}
+#    ::= {objectClass 2}
+#
+#
+#    locality OBJECT-CLASS
+#        SUBCLASS OF top
+#        MAY CONTAIN {
+#            description,
+#            localityName,
+#            stateOrProvinceName,
+#            searchGuide,
+#            seeAlso,
+#            streetAddress}
+#    ::= {objectClass 3}
+#
+#
+#    organization OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            organizationName}
+#        MAY CONTAIN {
+#            organizationalAttributeSet}
+#    ::= {objectClass 4}
+#
+#
+#    organizationalUnit OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            organizationalUnitName}
+#        MAY CONTAIN {
+#            organizationalAttributeSet}
+#    ::= {objectClass 5}
+#
+#
+#    person OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName,
+#            surname}
+#        MAY CONTAIN {
+#            description,
+#            seeAlso,
+#            telephoneNumber,
+#            userPassword}
+#    ::= {objectClass 6}
+#
+#
+#    organizationalPerson OBJECT-CLASS
+#        SUBCLASS OF person
+#        MAY CONTAIN {
+#            localeAttributeSet,
+#            organizationalUnitName,
+#            postalAttributeSet,
+#            telecommunicationAttributeSet,
+#            title}
+#    ::= {objectClass 7}
+#
+#
+#    organizationalRole OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            description,
+#            localeAttributeSet,
+#            organizationalUnitName,
+#            postalAttributeSet,
+#            preferredDeliveryMethod,
+#            roleOccupant,
+#            seeAlso,
+#            telecommunicationAttributeSet}
+#    ::= {objectClass 8}
+#
+#
+#    groupOfNames OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName,
+#            member}
+#        MAY CONTAIN {
+#            description,
+#            organizationName,
+#            organizationalUnitName,
+#            owner,
+#            seeAlso,
+#            businessCategory}
+#    ::= {objectClass 9}
+#
+#
+#    residentialPerson OBJECT-CLASS
+#        SUBCLASS OF person
+#        MUST CONTAIN {
+#            localityName}
+#        MAY CONTAIN {
+#            localeAttributeSet,
+#            postalAttributeSet,
+#            preferredDeliveryMethod,
+#            telecommunicationAttributeSet,
+#            businessCategory}
+#    ::= {objectClass 10}
+#
+#
+#    applicationProcess OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            description,
+#            localityName,
+#            organizationalUnitName,
+#            seeAlso}
+#    ::= {objectClass 11}
+#
+#
+#    applicationEntity OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName,
+#            presentationAddress}
+#        MAY CONTAIN {
+#            description,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName,
+#            seeAlso,
+#            supportedApplicationContext}
+#    ::= {objectClass 12}
+#
+#
+#    dSA OBJECT-CLASS
+#        SUBCLASS OF applicationEntity
+#        MAY CONTAIN {
+#            knowledgeInformation}
+#    ::= {objectClass 13}
+#
+#
+#    device OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            description,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName,
+#            owner,
+#            seeAlso,
+#            serialNumber}
+#    ::= {objectClass 14}
+#
+#
+#    strongAuthenticationUser OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            userCertificate}
+#    ::= {objectClass 15}
+#
+#
+#    certificationAuthority OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            cACertificate,
+#            certificateRevocationList,
+#            authorityRevocationList}
+#        MAY CONTAIN {
+#            crossCertificatePair}
+#    ::= {objectClass 16}
+#
+#    -- Standard MHS Object Classes
+#
+#    mhsDistributionList OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName,
+#            mhsDLSubmitPermissions,
+#            mhsORAddresses}
+#        MAY CONTAIN {
+#            description,
+#            organizationName,
+#            organizationalUnitName,
+#            owner,
+#            seeAlso,
+#            mhsDeliverableContentTypes,
+#            mhsdeliverableEits,
+#            mhsDLMembers,
+#            mhsPreferredDeliveryMethods}
+#    ::= {mhsObjectClass 0}
+#
+#
+#    mhsMessageStore OBJECT-CLASS
+#        SUBCLASS OF applicationEntity
+#        MAY CONTAIN {
+#            description,
+#            owner,
+#            mhsSupportedOptionalAttributes,
+#            mhsSupportedAutomaticActions,
+#            mhsSupportedContentTypes}
+#    ::= {mhsObjectClass 1}
+#
+#
+#    mhsMessageTransferAgent OBJECT-CLASS
+#        SUBCLASS OF applicationEntity
+#        MAY CONTAIN {
+#            description,
+#            owner,
+#            mhsDeliverableContentLength}
+#    ::= {mhsObjectClass 2}
+#
+#
+#    mhsOrganizationalUser OBJECT-CLASS
+#        SUBCLASS OF organizationalPerson
+#        MUST CONTAIN {
+#            mhsORAddresses}
+#        MAY CONTAIN {
+#            mhsDeliverableContentLength,
+#            mhsDeliverableContentTypes,
+#            mhsDeliverableEits,
+#            mhsMessageStoreName,
+#            mhsPreferredDeliveryMethods }
+#    ::= {mhsObjectClass 3}
+#
+#
+#    mhsResidentialUser OBJECT-CLASS
+#        SUBCLASS OF residentialPerson
+#        MUST CONTAIN {
+#            mhsORAddresses}
+#        MAY CONTAIN {
+#            mhsDeliverableContentLength,
+#            mhsDeliverableContentTypes,
+#            mhsDeliverableEits,
+#            mhsMessageStoreName,
+#            mhsPreferredDeliveryMethods }
+#    ::= {mhsObjectClass 4}
+#
+#
+#    mhsUserAgent OBJECT-CLASS
+#        SUBCLASS OF applicationEntity
+#        MAY CONTAIN {
+#            mhsDeliverableContentLength,
+#            mhsDeliverableContentTypes,
+#            mhsDeliverableEits,
+#            mhsORAddresses,
+#            owner}
+#    ::= {mhsObjectClass 5}
+#
+#
+#
+#
+#    -- Pilot Object Classes
+#
+#    pilotObject OBJECT-CLASS
+#        SUBCLASS OF top
+#        MAY CONTAIN {
+#            info,
+#            photo,
+#            manager,
+#            uniqueIdentifier,
+#            lastModifiedTime,
+#            lastModifiedBy,
+#            dITRedirect,
+#            audio}
+#    ::= {pilotObjectClass 3}
+#    pilotPerson OBJECT-CLASS
+#        SUBCLASS OF person
+#        MAY CONTAIN {
+#                    userid,
+#                    textEncodedORAddress,
+#                    rfc822Mailbox,
+#                    favouriteDrink,
+#                    roomNumber,
+#                    userClass,
+#                    homeTelephoneNumber,
+#                    homePostalAddress,
+#                    secretary,
+#                    personalTitle,
+#                    preferredDeliveryMethod,
+#                    businessCategory,
+#                    janetMailbox,
+#                    otherMailbox,
+#                    mobileTelephoneNumber,
+#                    pagerTelephoneNumber,
+#                    organizationalStatus,
+#                    mailPreferenceOption,
+#                    personalSignature}
+#    ::= {pilotObjectClass 4}
+#
+#
+#    account OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            userid}
+#        MAY CONTAIN {
+#            description,
+#            seeAlso,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName,
+#            host}
+#    ::= {pilotObjectClass 5}
+#
+#
+#    document OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            documentIdentifier}
+#        MAY CONTAIN {
+#            commonName,
+#            description,
+#            seeAlso,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName,
+#            documentTitle,
+#            documentVersion,
+#            documentAuthor,
+#            documentLocation,
+#            documentPublisher}
+#    ::= {pilotObjectClass 6}
+#
+#
+#    room OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            roomNumber,
+#            description,
+#            seeAlso,
+#            telephoneNumber}
+#    ::= {pilotObjectClass 7}
+#
+#
+#    documentSeries OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            commonName}
+#        MAY CONTAIN {
+#            description,
+#            seeAlso,
+#            telephoneNumber,
+#            localityName,
+#            organizationName,
+#            organizationalUnitName}
+#    ::= {pilotObjectClass 9}
+#
+#
+#    domain OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            domainComponent}
+#        MAY CONTAIN {
+#            associatedName,
+#            organizationName,
+#            organizationalAttributeSet}
+#    ::= {pilotObjectClass 13}
+#
+#
+#    rFC822localPart OBJECT-CLASS
+#        SUBCLASS OF domain
+#        MAY CONTAIN {
+#            commonName,
+#            surname,
+#            description,
+#            seeAlso,
+#            telephoneNumber,
+#            postalAttributeSet,
+#            telecommunicationAttributeSet}
+#    ::= {pilotObjectClass 14}
+#
+#
+#    dNSDomain OBJECT-CLASS
+#        SUBCLASS OF domain
+#        MAY CONTAIN {
+#            ARecord,
+#            MDRecord,
+#            MXRecord,
+#            NSRecord,
+#            SOARecord,
+#            CNAMERecord}
+#    ::= {pilotObjectClass 15}
+#
+#
+#    domainRelatedObject OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            associatedDomain}
+#    ::= {pilotObjectClass 17}
+#
+#
+#    friendlyCountry OBJECT-CLASS
+#        SUBCLASS OF country
+#        MUST CONTAIN {
+#            friendlyCountryName}
+#    ::= {pilotObjectClass 18}
+#
+#
+#    simpleSecurityObject OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            userPassword }
+#    ::= {pilotObjectClass 19}
+#
+#
+#    pilotOrganization OBJECT-CLASS
+#        SUBCLASS OF organization, organizationalUnit
+#        MAY CONTAIN {
+#                    buildingName}
+#    ::= {pilotObjectClass 20}
+#
+#
+#    pilotDSA OBJECT-CLASS
+#        SUBCLASS OF dsa
+#        MUST CONTAIN {
+#            dSAQuality}
+#    ::= {pilotObjectClass 21}
+#
+#
+#    qualityLabelledData OBJECT-CLASS
+#        SUBCLASS OF top
+#        MUST CONTAIN {
+#            dSAQuality}
+#        MAY CONTAIN {
+#            subtreeMinimumQuality,
+#            subtreeMaximumQuality}
+#    ::= {pilotObjectClass 22}
+#
+#
+#
+#
+#    -- Standard Attribute Types
+#
+#    objectClass ObjectClass
+#        ::= {attributeType 0}
+#
+#
+#    aliasedObjectName AliasedObjectName
+#        ::= {attributeType 1}
+#
+#
+#    knowledgeInformation ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreString
+#        ::= {attributeType 2}
+#
+#
+#    commonName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-common-name))
+#        ::= {attributeType 3}
+#
+#
+#    surname ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-surname))
+#        ::= {attributeType 4}
+#
+#
+#    serialNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX printableStringSyntax
+#        (SIZE (1..ub-serial-number))
+#        ::= {attributeType 5}
+#
+#
+#    countryName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX PrintableString
+#        (SIZE (1..ub-country-code))
+#        SINGLE VALUE
+#        ::= {attributeType 6}
+#
+#
+#    localityName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-locality-name))
+#        ::= {attributeType 7}
+#
+#
+#    stateOrProvinceName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-state-name))
+#        ::= {attributeType 8}
+#
+#
+#    streetAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-street-address))
+#        ::= {attributeType 9}
+#
+#
+#    organizationName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-organization-name))
+#        ::= {attributeType 10}
+#
+#
+#    organizationalUnitName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-organizational-unit-name))
+#        ::= {attributeType 11}
+#
+#
+#    title ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-title))
+#        ::= {attributeType 12}
+#
+#
+#    description ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-description))
+#        ::= {attributeType 13}
+#
+#
+#    searchGuide ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX Guide
+#        ::= {attributeType 14}
+#
+#
+#    businessCategory ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-business-category))
+#        ::= {attributeType 15}
+#
+#
+#    postalAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX PostalAddress
+#        MATCHES FOR EQUALITY
+#        ::= {attributeType 16}
+#
+#
+#    postalCode ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-postal-code))
+#        ::= {attributeType 17}
+#
+#
+#    postOfficeBox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-post-office-box))
+#        ::= {attributeType 18}
+#
+#
+#    physicalDeliveryOfficeName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX caseIgnoreStringSyntax
+#        (SIZE (1..ub-physical-office-name))
+#        ::= {attributeType 19}
+#
+#
+#    telephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX telephoneNumberSyntax
+#        (SIZE (1..ub-telephone-number))
+#        ::= {attributeType 20}
+#
+#
+#    telexNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX TelexNumber
+#        (SIZE (1..ub-telex))
+#        ::= {attributeType 21}
+#
+#
+#    teletexTerminalIdentifier ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX TeletexTerminalIdentifier
+#        (SIZE (1..ub-teletex-terminal-id))
+#        ::= {attributeType 22}
+#
+#
+#    facsimileTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX FacsimileTelephoneNumber
+#        ::= {attributeType 23}
+#
+#
+#    x121Address ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX NumericString
+#        (SIZE (1..ub-x121-address))
+#        ::= {attributeType 24}
+#
+#
+#    internationaliSDNNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX NumericString
+#        (SIZE (1..ub-isdn-address))
+#        ::= {attributeType 25}
+#
+#
+#    registeredAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX PostalAddress
+#        ::= {attributeType 26}
+#
+#
+#    destinationIndicator ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX PrintableString
+#        (SIZE (1..ub-destination-indicator))
+#        MATCHES FOR EQUALITY SUBSTRINGS
+#        ::= {attributeType 27}
+#
+#
+#    preferredDeliveryMethod ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX deliveryMethod
+#        ::= {attributeType 28}
+#
+#
+#    presentationAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX PresentationAddress
+#        MATCHES FOR EQUALITY
+#        ::= {attributeType 29}
+#
+#
+#    supportedApplicationContext ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX objectIdentifierSyntax
+#        ::= {attributeType 30}
+#
+#
+#    member ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX distinguishedNameSyntax
+#        ::= {attributeType 31}
+#
+#
+#    owner ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX distinguishedNameSyntax
+#        ::= {attributeType 32}
+#
+#
+#    roleOccupant ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX distinguishedNameSyntax
+#        ::= {attributeType 33}
+#
+#
+#    seeAlso ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX distinguishedNameSyntax
+#        ::= {attributeType 34}
+#
+#
+#    userPassword ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX Userpassword
+#        ::= {attributeType 35}
+#
+#
+#    userCertificate ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX UserCertificate
+#        ::= {attributeType 36}
+#
+#
+#    cACertificate ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX cACertificate
+#        ::= {attributeType 37}
+#
+#
+#    authorityRevocationList ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX AuthorityRevocationList
+#        ::= {attributeType 38}
+#
+#
+#    certificateRevocationList ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX CertificateRevocationList
+#        ::= {attributeType 39}
+#
+#
+#    crossCertificatePair ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX CrossCertificatePair
+#        ::= {attributeType 40}
+#
+#
+#
+#
+#    -- Standard MHS Attribute Types
+#
+#    mhsDeliverableContentLength ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX integer
+#        ::= {mhsAttributeType 0}
+#
+#
+#    mhsDeliverableContentTypes ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX oID
+#        ::= {mhsAttributeType 1}
+#
+#
+#    mhsDeliverableEits ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX oID
+#        ::= {mhsAttributeType 2}
+#
+#
+#    mhsDLMembers ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX oRName
+#        ::= {mhsAttributeType 3}
+#
+#
+#    mhsDLSubmitPermissions ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX dLSubmitPermission
+#        ::= {mhsAttributeType 4}
+#
+#
+#    mhsMessageStoreName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX dN
+#        ::= {mhsAttributeType 5}
+#
+#
+#    mhsORAddresses ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX oRAddress
+#        ::= {mhsAttributeType 6}
+#
+#
+#    mhsPreferredDeliveryMethods ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX deliveryMethod
+#        ::= {mhsAttributeType 7}
+#
+#
+#    mhsSupportedAutomaticActions ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX oID
+#        ::= {mhsAttributeType 8}
+#
+#
+#    mhsSupportedContentTypes ATTRIBUTE
+#
+#        WITH ATTRIBUTE-SYNTAX oID
+#        ::= {mhsAttributeType 9}
+#
+#
+#    mhsSupportedOptionalAttributes ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX oID
+#        ::= {mhsAttributeType 10}
+#
+#
+#
+#
+#    -- Pilot Attribute Types
+#
+#    userid ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-user-identifier))
+#    ::= {pilotAttributeType 1}
+#
+#
+#    textEncodedORAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#        (SIZE (1 .. ub-text-encoded-or-address))
+#    ::= {pilotAttributeType 2}
+#
+#
+#    rfc822Mailbox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#            (SIZE (1 .. ub-rfc822-mailbox))
+#    ::= {pilotAttributeType 3}
+#
+#
+#    info ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-information))
+#    ::= {pilotAttributeType 4}
+#
+#
+#    favouriteDrink ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-favourite-drink))
+#    ::= {pilotAttributeType 5}
+#
+#
+#    roomNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-room-number))
+#    ::= {pilotAttributeType 6}
+#
+#
+#    photo ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            CHOICE {
+#                g3-facsimile [3] G3FacsimileBodyPart
+#                }
+#        (SIZE (1 .. ub-photo))
+#    ::= {pilotAttributeType 7}
+#
+#
+#    userClass ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-user-class))
+#    ::= {pilotAttributeType 8}
+#
+#
+#    host ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-host))
+#    ::= {pilotAttributeType 9}
+#
+#
+#    manager ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 10}
+#
+#
+#    documentIdentifier ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-document-identifier))
+#    ::= {pilotAttributeType 11}
+#
+#
+#    documentTitle ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#        (SIZE (1 .. ub-document-title))
+#    ::= {pilotAttributeType 12}
+#
+#
+#    documentVersion ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-document-version))
+#    ::= {pilotAttributeType 13}
+#
+#
+#    documentAuthor ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 14}
+#
+#
+#    documentLocation ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-document-location))
+#    ::= {pilotAttributeType 15}
+#
+#
+#    homeTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            telephoneNumberSyntax
+#    ::= {pilotAttributeType 20}
+#
+#
+#    secretary ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 21}
+#
+#
+#    otherMailbox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            SEQUENCE {
+#                    mailboxType PrintableString, -- e.g. Telemail
+#                    mailbox IA5String  -- e.g. X378:Joe
+#            }
+#    ::= {pilotAttributeType 22}
+#
+#
+#    lastModifiedTime ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            uTCTimeSyntax
+#    ::= {pilotAttributeType 23}
+#
+#
+#    lastModifiedBy ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 24}
+#
+#
+#    domainComponent ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#            SINGLE VALUE
+#    ::= {pilotAttributeType 25}
+#
+#
+#    aRecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 26}
+#
+#
+#    mXRecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 28}
+#
+#
+#    nSRecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 29}
+#
+#    sOARecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            DNSRecordSyntax
+#    ::= {pilotAttributeType 30}
+#
+#
+#    cNAMERecord ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            iA5StringSyntax
+#    ::= {pilotAttributeType 31}
+#
+#
+#    associatedDomain ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#    ::= {pilotAttributeType 37}
+#
+#
+#    associatedName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 38}
+#
+#
+#    homePostalAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            postalAddress
+#            MATCHES FOR EQUALITY
+#    ::= {pilotAttributeType 39}
+#
+#
+#    personalTitle ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-personal-title))
+#    ::= {pilotAttributeType 40}
+#
+#
+#    mobileTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            telephoneNumberSyntax
+#    ::= {pilotAttributeType 41}
+#
+#
+#    pagerTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            telephoneNumberSyntax
+#    ::= {pilotAttributeType 42}
+#
+#
+#    friendlyCountryName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#    ::= {pilotAttributeType 43}
+#
+#
+#    uniqueIdentifier ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-unique-identifier))
+#    ::= {pilotAttributeType 44}
+#
+#
+#    organizationalStatus ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-organizational-status))
+#    ::= {pilotAttributeType 45}
+#
+#
+#    janetMailbox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreIA5StringSyntax
+#            (SIZE (1 .. ub-janet-mailbox))
+#    ::= {pilotAttributeType 46}
+#
+#
+#    mailPreferenceOption ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX ENUMERATED {
+#                no-list-inclusion(0),
+#                any-list-inclusion(1),  -- may be added to any lists
+#                professional-list-inclusion(2)
+#                                        -- may be added to lists
+#                                        -- which the list provider
+#                                        -- views as related to the
+#                                        -- users professional inter-
+#                                        -- ests, perhaps evaluated
+#                                        -- from the business of the
+#                                        -- organisation or keywords
+#                                        -- in the entry.
+#                }
+#    ::= {pilotAttributeType 47}
+#
+#
+#    buildingName ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-building-name))
+#    ::= {pilotAttributeType 48}
+#
+#
+#    dSAQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DSAQualitySyntax
+#            SINGLE VALUE
+#    ::= {pilotAttributeType 49}
+#
+#
+#    singleLevelQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DataQualitySyntax
+#            SINGLE VALUE
+#
+#
+#    subtreeMinimumQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DataQualitySyntax
+#            SINGLE VALUE
+#               -- Defaults to singleLevelQuality
+#    ::= {pilotAttributeType 51}
+#
+#
+#    subtreeMaximumQuality ATTRIBUTE
+#            WITH ATTRIBUTE-SYNTAX DataQualitySyntax
+#            SINGLE VALUE
+#               -- Defaults to singleLevelQuality
+#    ::= {pilotAttributeType 52}
+#
+#
+#    personalSignature ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            CHOICE {
+#                g3-facsimile [3] G3FacsimileBodyPart
+#                }
+#        (SIZE (1 .. ub-personal-signature))
+#    ::= {pilotAttributeType 53}
+#
+#
+#    dITRedirect ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 54}
+#
+#
+#    audio ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            Audio
+#        (SIZE (1 .. ub-audio))
+#    ::= {pilotAttributeType 55}
+#
+#    documentPublisher ATTRIBUTE
+#            WITH ATTRIBUTE SYNTAX caseIgnoreStringSyntax
+#    ::= {pilotAttributeType 56}
+#
+#
+#
+#    -- Generally useful syntaxes
+#
+#
+#    caseIgnoreIA5StringSyntax ATTRIBUTE-SYNTAX
+#            IA5String
+#            MATCHES FOR EQUALITY SUBSTRINGS
+#
+#
+#    iA5StringSyntax ATTRIBUTE-SYNTAX
+#        IA5String
+#        MATCHES FOR EQUALITY SUBSTRINGS
+#
+#
+#    -- Syntaxes to support the DNS attributes
+#
+#    DNSRecordSyntax ATTRIBUTE-SYNTAX
+#            IA5String
+#            MATCHES FOR EQUALITY
+#
+#
+#    NRSInformationSyntax ATTRIBUTE-SYNTAX
+#            NRSInformation
+#            MATCHES FOR EQUALITY
+#
+#
+#    NRSInformation ::=  SET {
+#                    [0] Context,
+#                    [1] Address-space-id,
+#                    routes [2] SEQUENCE OF SEQUENCE {
+#                    Route-cost,
+#                    Addressing-info }
+#            }
+#
+#
+#    -- Upper bounds on length of attribute values
+#
+#
+#    ub-document-identifier INTEGER ::= 256
+#
+#    ub-document-location INTEGER ::= 256
+#
+#    ub-document-title INTEGER ::= 256
+#
+#    ub-document-version INTEGER ::= 256
+#
+#    ub-favourite-drink INTEGER ::= 256
+#
+#    ub-host INTEGER ::= 256
+#
+#    ub-information INTEGER ::= 2048
+#
+#    ub-unique-identifier INTEGER ::= 256
+#
+#    ub-personal-title INTEGER ::= 256
+#
+#    ub-photo INTEGER ::= 250000
+#
+#    ub-rfc822-mailbox INTEGER ::= 256
+#
+#    ub-room-number INTEGER ::= 256
+#
+#    ub-text-or-address INTEGER ::= 256
+#
+#    ub-user-class INTEGER ::= 256
+#
+#    ub-user-identifier INTEGER ::= 256
+#
+#    ub-organizational-status INTEGER ::= 256
+#
+#    ub-janet-mailbox INTEGER ::= 256
+#
+#    ub-building-name INTEGER ::= 256
+#
+#    ub-personal-signature ::= 50000
+#
+#    ub-audio INTEGER ::= 250000
+#
+# [remainder of memo trimmed]
+

--- a/scripts/docker/auth/openldap/schema/duaconf.schema
+++ b/scripts/docker/auth/openldap/schema/duaconf.schema
@@ -1,0 +1,261 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+
+# DUA schema from draft-joslin-config-schema (a work in progress)
+
+# Contents of this file are subject to change (including deletion)
+# without notice.
+#
+# Not recommended for production use!
+# Use with extreme caution!
+
+## Notes:
+## - The matching rule for attributes followReferrals and dereferenceAliases
+##   has been changed to booleanMatch since their syntax is boolean
+## - There was a typo in the name of the dereferenceAliases attributeType
+##   in the DUAConfigProfile objectClass definition
+## - Credit goes to the original Authors
+
+# 
+# Application Working Group                                      M. Ansari
+# INTERNET-DRAFT                                    Sun Microsystems, Inc.
+# Expires Febuary 2003                                           L. Howard
+#                                                  PADL Software Pty. Ltd.
+#                                                          B. Joslin [ed.]
+#                                                  Hewlett-Packard Company
+# 
+#                                                     September 15th, 2003
+# Intended Category: Informational
+# 
+# 
+#                  A Configuration Schema for LDAP Based
+#                          Directory User Agents
+#                   <draft-joslin-config-schema-07.txt>
+#
+#Status of this Memo
+#
+#    This memo provides information for the Internet community.  This
+#    memo does not specify an Internet standard of any kind.  Distribu-
+#    tion of this memo is unlimited.
+#         
+#    This document is an Internet-Draft and is in full conformance with
+#    all provisions of Section 10 of RFC2026.
+#    
+#    This document is an Internet-Draft. Internet-Drafts are working  
+#    documents of the Internet Engineering Task Force (IETF), its areas,
+#    and its working groups. Note that other groups may also distribute
+#    working documents as Internet-Drafts.
+#    
+#    Internet-Drafts are draft documents valid for a maximum of six
+#    months.  Internet-Drafts may be updated, replaced, or made obsolete
+#    by other documents at any time. It is not appropriate to use 
+#    Internet-Drafts as reference material or to cite them other than as
+#    a "working draft" or "work in progress".                
+#         
+#    To learn the current status of any Internet-Draft, please check the
+#    1id-abstracts.txt listing contained in the Internet-Drafts Shadow 
+#    Directories on ds.internic.net (US East Coast), nic.nordu.net      
+#    (Europe), ftp.isi.edu (US West Coast), or munnari.oz.au (Pacific
+#    Rim).
+#    
+#    Distribution of this document is unlimited.
+# 
+# 
+# Abstract
+# 
+#      This document describes a mechanism for global configuration of
+#      similar directory user agents.  This document defines a schema for
+#      configuration of these DUAs that may be discovered using the Light-
+#      weight Directory Access Protocol in RFC 2251[17].  A set of attri-
+#      bute types and an objectclass are proposed, along with specific
+#      guidelines for interpreting them.  A significant feature of the
+#      global configuration policy for DUAs is a mechanism that allows
+#      DUAs to re-configure their schema to that of the end user's
+#      environment.  This configuration is achieved through attribute and
+#      objectclass mapping.  This document is intended to be a skeleton
+#      for future documents that describe configuration of specific DUA
+#      services.
+# 
+# 
+# [trimmed]
+# 
+# 
+# 2.  General Issues
+# 
+#      The schema defined by this document is defined under the "DUA Con-
+#      figuration Schema."  This schema is derived from the OID: iso (1)
+#      org (3) dod (6) internet (1) private (4) enterprises (1) Hewlett-
+#      Packard Company (11) directory (1) LDAP-UX Integration Project (3)
+#      DUA Configuration Schema (1).  This OID is represented in this
+#      document by the keystring "DUAConfSchemaOID"
+#      (1.3.6.1.4.1.11.1.3.1).
+objectidentifier DUAConfSchemaOID 1.3.6.1.4.1.11.1.3.1
+# 
+# 2.2 Attributes
+# 
+#      The attributes and classes defined in this document are summarized
+#      below.
+# 
+#      The following attributes are defined in this document:
+# 
+#           preferredServerList
+#           defaultServerList
+#           defaultSearchBase
+#           defaultSearchScope
+#           authenticationMethod
+#           credentialLevel
+#           serviceSearchDescriptor
+# 
+# 
+# 
+# Joslin                                                         [Page 3]
+# Internet-Draft          DUA Configuration Schema            October 2002
+# 
+# 
+#           serviceCredentialLevel
+#           serviceAuthenticationMethod
+#           attributeMap
+#           objectclassMap
+#           searchTimeLimit
+#           bindTimeLimit
+#           followReferrals
+#           dereferenceAliases
+#           profileTTL
+# 
+# 2.3 Object Classes
+# 
+#      The following object class is defined in this document:
+# 
+#           DUAConfigProfile
+# 
+# 
+attributeType ( DUAConfSchemaOID:1.0 NAME 'defaultServerList'
+            DESC 'Default LDAP server host address used by a DUA'
+            EQUALITY caseIgnoreMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.1 NAME 'defaultSearchBase'
+            DESC 'Default LDAP base DN used by a DUA'
+            EQUALITY distinguishedNameMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.2 NAME 'preferredServerList'
+            DESC 'Preferred LDAP server host addresses to be used by a
+            DUA'
+            EQUALITY caseIgnoreMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.3 NAME 'searchTimeLimit'
+            DESC 'Maximum time in seconds a DUA should allow for a
+            search to complete'
+            EQUALITY integerMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.4 NAME 'bindTimeLimit'
+            DESC 'Maximum time in seconds a DUA should allow for the
+            bind operation to complete'
+            EQUALITY integerMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.5 NAME 'followReferrals'
+            DESC 'Tells DUA if it should follow referrals
+            returned by a DSA search result'
+            EQUALITY booleanMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.16 NAME 'dereferenceAliases'
+            DESC 'Tells DUA if it should dereference aliases'
+            EQUALITY booleanMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.6 NAME 'authenticationMethod'
+            DESC 'A keystring which identifies the type of
+            authentication method used to contact the DSA'
+            EQUALITY caseIgnoreMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.7 NAME 'profileTTL'
+            DESC 'Time to live, in seconds, before a client DUA
+            should re-read this configuration profile'
+            EQUALITY integerMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.14 NAME 'serviceSearchDescriptor'
+            DESC 'LDAP search descriptor list used by a DUA'
+            EQUALITY caseExactMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+attributeType ( DUAConfSchemaOID:1.9 NAME 'attributeMap'
+            DESC 'Attribute mappings used by a DUA'
+            EQUALITY caseIgnoreIA5Match
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributeType ( DUAConfSchemaOID:1.10 NAME 'credentialLevel'
+            DESC 'Identifies type of credentials a DUA should
+            use when binding to the LDAP server'
+            EQUALITY caseIgnoreIA5Match
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.11 NAME 'objectclassMap'
+            DESC 'Objectclass mappings used by a DUA'
+            EQUALITY caseIgnoreIA5Match
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributeType ( DUAConfSchemaOID:1.12 NAME 'defaultSearchScope'
+            DESC 'Default search scope used by a DUA'
+            EQUALITY caseIgnoreIA5Match
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+            SINGLE-VALUE )
+
+attributeType ( DUAConfSchemaOID:1.13 NAME 'serviceCredentialLevel'
+            DESC 'Identifies type of credentials a DUA
+            should use when binding to the LDAP server for a
+            specific service'
+            EQUALITY caseIgnoreIA5Match
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributeType ( DUAConfSchemaOID:1.15 NAME 'serviceAuthenticationMethod'
+            DESC 'Authentication method used by a service of the DUA'
+            EQUALITY caseIgnoreMatch
+            SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+# 
+# 4.  Class Definition
+# 
+#      The objectclass below is constructed from the attributes defined in
+#      3, with the exception of the cn attribute, which is defined in RFC
+#      2256 [8].  cn is used to represent the name of the DUA configura-
+#      tion profile.
+# 
+objectClass ( DUAConfSchemaOID:2.5 NAME 'DUAConfigProfile'
+          SUP top STRUCTURAL
+          DESC 'Abstraction of a base configuration for a DUA'
+          MUST ( cn )
+          MAY ( defaultServerList $ preferredServerList $
+                defaultSearchBase $ defaultSearchScope $
+                searchTimeLimit $ bindTimeLimit $
+                credentialLevel $ authenticationMethod $
+                followReferrals $ dereferenceAliases $
+                serviceSearchDescriptor $ serviceCredentialLevel $
+                serviceAuthenticationMethod $ objectclassMap $
+                attributeMap $ profileTTL ) )

--- a/scripts/docker/auth/openldap/schema/dyngroup.schema
+++ b/scripts/docker/auth/openldap/schema/dyngroup.schema
@@ -1,0 +1,91 @@
+# dyngroup.schema -- Dynamic Group schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Dynamic Group schema (experimental), as defined by Netscape.  See
+# http://www.redhat.com/docs/manuals/ent-server/pdf/esadmin611.pdf
+# page 70 for details on how these groups were used.
+#
+# A description of the objectclass definition is available here:
+# http://www.redhat.com/docs/manuals/dir-server/schema/7.1/oc_dir.html#1303745
+#
+# depends upon:
+#	core.schema
+#
+# These definitions are considered experimental due to the lack of
+# a formal specification (e.g., RFC).
+#
+# NOT RECOMMENDED FOR PRODUCTION USE!  USE WITH CAUTION!
+#
+# The Netscape documentation describes this as an auxiliary objectclass
+# but their implementations have always defined it as a structural class.
+# The sloppiness here is because Netscape-derived servers don't actually
+# implement the X.500 data model, and they don't honor the distinction
+# between structural and auxiliary classes. This fact is noted here:
+# http://forum.java.sun.com/thread.jspa?threadID=5016864&messageID=9034636
+#
+# In accordance with other existing implementations, we define it as a
+# structural class.
+#
+# Our definition of memberURL also does not match theirs but again
+# their published definition and what works in practice do not agree.
+# In other words, the Netscape definitions are broken and interoperability
+# is not guaranteed.
+#
+# Also see the new DynGroup proposed spec at
+# http://tools.ietf.org/html/draft-haripriya-dynamicgroup-02
+
+objectIdentifier NetscapeRoot 2.16.840.1.113730
+
+objectIdentifier NetscapeLDAP NetscapeRoot:3
+objectIdentifier NetscapeLDAPattributeType NetscapeLDAP:1
+objectIdentifier NetscapeLDAPobjectClass NetscapeLDAP:2
+
+objectIdentifier OpenLDAPExp11	1.3.6.1.4.1.4203.666.11
+objectIdentifier DynGroupBase	OpenLDAPExp11:8
+objectIdentifier DynGroupAttr	DynGroupBase:1
+objectIdentifier DynGroupOC	DynGroupBase:2
+
+attributetype ( NetscapeLDAPattributeType:198
+	NAME 'memberURL'
+	DESC 'Identifies an URL associated with each member of a group. Any type of labeled URL can be used.'
+	SUP labeledURI )
+
+attributetype ( DynGroupAttr:1
+	NAME 'dgIdentity'
+	DESC 'Identity to use when processing the memberURL'
+	SUP distinguishedName SINGLE-VALUE )
+
+attributeType ( DynGroupAttr:2
+	NAME 'dgAuthz'
+	DESC 'Optional authorization rules that determine who is allowed to assume the dgIdentity'
+	EQUALITY authzMatch
+	SYNTAX 1.3.6.1.4.1.4203.666.2.7
+	X-ORDERED 'VALUES' )
+
+objectClass ( NetscapeLDAPobjectClass:33
+	NAME 'groupOfURLs'
+	SUP top STRUCTURAL
+	MUST cn
+	MAY ( memberURL $ businessCategory $ description $ o $ ou $
+		owner $ seeAlso ) )
+
+# The Haripriya dyngroup schema still needs a lot of work.
+# We're just adding support for the dgIdentity attribute for now...
+objectClass ( DynGroupOC:1
+	NAME 'dgIdentityAux'
+	SUP top AUXILIARY
+	MAY ( dgIdentity $ dgAuthz ) )
+
+

--- a/scripts/docker/auth/openldap/schema/inetorgperson.schema
+++ b/scripts/docker/auth/openldap/schema/inetorgperson.schema
@@ -1,0 +1,156 @@
+# inetorgperson.schema -- InetOrgPerson (RFC2798)
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# InetOrgPerson (RFC2798)
+#
+# Depends upon
+#   Definition of an X.500 Attribute Type and an Object Class to Hold
+#   Uniform Resource Identifiers (URIs) [RFC2079]
+#	(core.schema)
+#
+#   A Summary of the X.500(96) User Schema for use with LDAPv3 [RFC2256]
+#	(core.schema)
+#
+#   The COSINE and Internet X.500 Schema [RFC1274] (cosine.schema)
+
+# carLicense
+# This multivalued field is used to record the values of the license or
+# registration plate associated with an individual.
+attributetype ( 2.16.840.1.113730.3.1.1
+	NAME 'carLicense'
+	DESC 'RFC2798: vehicle license or registration plate'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# departmentNumber
+# Code for department to which a person belongs.  This can also be
+# strictly numeric (e.g., 1234) or alphanumeric (e.g., ABC/123).
+attributetype ( 2.16.840.1.113730.3.1.2
+	NAME 'departmentNumber'
+	DESC 'RFC2798: identifies a department within an organization'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# displayName
+# When displaying an entry, especially within a one-line summary list, it
+# is useful to be able to identify a name to be used.  Since other attri-
+# bute types such as 'cn' are multivalued, an additional attribute type is
+# needed.  Display name is defined for this purpose.
+attributetype ( 2.16.840.1.113730.3.1.241
+	NAME 'displayName'
+	DESC 'RFC2798: preferred name to be used when displaying entries'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE )
+
+# employeeNumber
+# Numeric or alphanumeric identifier assigned to a person, typically based
+# on order of hire or association with an organization.  Single valued.
+attributetype ( 2.16.840.1.113730.3.1.3
+	NAME 'employeeNumber'
+	DESC 'RFC2798: numerically identifies an employee within an organization'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE )
+
+# employeeType
+# Used to identify the employer to employee relationship.  Typical values
+# used will be "Contractor", "Employee", "Intern", "Temp", "External", and
+# "Unknown" but any value may be used.
+attributetype ( 2.16.840.1.113730.3.1.4
+	NAME 'employeeType'
+	DESC 'RFC2798: type of employment for a person'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# jpegPhoto
+# Used to store one or more images of a person using the JPEG File
+# Interchange Format [JFIF].
+# Note that the jpegPhoto attribute type was defined for use in the
+# Internet X.500 pilots but no referencable definition for it could be
+# located.
+attributetype ( 0.9.2342.19200300.100.1.60
+	NAME 'jpegPhoto'
+	DESC 'RFC2798: a JPEG image'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.28 )
+
+# preferredLanguage
+# Used to indicate an individual's preferred written or spoken
+# language.  This is useful for international correspondence or human-
+# computer interaction.  Values for this attribute type MUST conform to
+# the definition of the Accept-Language header field defined in
+# [RFC2068] with one exception:  the sequence "Accept-Language" ":"
+# should be omitted.  This is a single valued attribute type.
+attributetype ( 2.16.840.1.113730.3.1.39
+	NAME 'preferredLanguage'
+	DESC 'RFC2798: preferred written or spoken language for a person'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE )
+
+# userSMIMECertificate
+# A PKCS#7 [RFC2315] SignedData, where the content that is signed is
+# ignored by consumers of userSMIMECertificate values.  It is
+# recommended that values have a `contentType' of data with an absent
+# `content' field.  Values of this attribute contain a person's entire
+# certificate chain and an smimeCapabilities field [RFC2633] that at a
+# minimum describes their SMIME algorithm capabilities.  Values for
+# this attribute are to be stored and requested in binary form, as
+# 'userSMIMECertificate;binary'.  If available, this attribute is
+# preferred over the userCertificate attribute for S/MIME applications.
+## OpenLDAP note: ";binary" transfer should NOT be used as syntax is binary
+attributetype ( 2.16.840.1.113730.3.1.40
+	NAME 'userSMIMECertificate'
+	DESC 'RFC2798: PKCS#7 SignedData used to support S/MIME'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 )
+
+# userPKCS12
+# PKCS #12 [PKCS12] provides a format for exchange of personal identity
+# information.  When such information is stored in a directory service,
+# the userPKCS12 attribute should be used. This attribute is to be stored
+# and requested in binary form, as 'userPKCS12;binary'.  The attribute
+# values are PFX PDUs stored as binary data.
+## OpenLDAP note: ";binary" transfer should NOT be used as syntax is binary
+attributetype ( 2.16.840.1.113730.3.1.216
+	NAME 'userPKCS12'
+	DESC 'RFC2798: personal identity information, a PKCS #12 PFX'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 )
+
+
+# inetOrgPerson
+# The inetOrgPerson represents people who are associated with an
+# organization in some way.  It is a structural class and is derived
+# from the organizationalPerson which is defined in X.521 [X521].
+objectclass	( 2.16.840.1.113730.3.2.2
+    NAME 'inetOrgPerson'
+	DESC 'RFC2798: Internet Organizational Person'
+    SUP organizationalPerson
+    STRUCTURAL
+	MAY (
+		audio $ businessCategory $ carLicense $ departmentNumber $
+		displayName $ employeeNumber $ employeeType $ givenName $
+		homePhone $ homePostalAddress $ initials $ jpegPhoto $
+		labeledURI $ mail $ manager $ mobile $ o $ pager $
+		photo $ roomNumber $ secretary $ uid $ userCertificate $
+		x500uniqueIdentifier $ preferredLanguage $
+		userSMIMECertificate $ userPKCS12 $ proxyAddresses $ 
+		department $ company $ mailNickname )
+	)

--- a/scripts/docker/auth/openldap/schema/java.schema
+++ b/scripts/docker/auth/openldap/schema/java.schema
@@ -1,0 +1,403 @@
+# java.schema -- Java Object Schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Java Object Schema (defined in RFC 2713)
+#	depends upon core.schema
+#
+
+# Network Working Group                                            V. Ryan
+# Request for Comments: 2713                                   S. Seligman
+# Category: Informational                                           R. Lee
+#                                                   Sun Microsystems, Inc.
+#                                                             October 1999
+# 
+# 
+#      Schema for Representing Java(tm) Objects in an LDAP Directory
+# 
+# Status of this Memo
+# 
+#    This memo provides information for the Internet community.  It does
+#    not specify an Internet standard of any kind.  Distribution of this
+#    memo is unlimited.
+# 
+# Copyright Notice
+# 
+#    Copyright (C) The Internet Society (1999).  All Rights Reserved.
+# 
+# Abstract
+# 
+#    This document defines the schema for representing Java(tm) objects in
+#    an LDAP directory [LDAPv3].  It defines schema elements to represent
+#    a Java serialized object [Serial], a Java marshalled object [RMI], a
+#    Java remote object [RMI], and a JNDI reference [JNDI].
+# 
+
+# [trimmed]
+
+# 3 Attribute Type Definitions
+# 
+#    The following attribute types are defined in this document:
+# 
+#        javaClassName
+#        javaClassNames
+#        javaCodebase
+#        javaSerializedData
+#        javaFactory
+#        javaReferenceAddress
+#        javaDoc
+# 
+# 3.1 javaClassName
+# 
+#    This attribute stores the fully qualified name of the Java object's
+#    "distinguished" class or interface (for example, "java.lang.String").
+#    It is a single-valued attribute. This attribute's syntax is '
+#    Directory String' and its case is significant.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.6
+#          NAME 'javaClassName'
+#          DESC 'Fully qualified name of distinguished Java class or
+#                interface'
+#          EQUALITY caseExactMatch
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+#          SINGLE-VALUE
+#        )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.6
+	NAME 'javaClassName'
+	DESC 'Fully qualified name of distinguished Java class or interface'
+	EQUALITY caseExactMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE )
+ 
+# 3.2 javaCodebase
+# 
+#    This attribute stores the Java class definition's locations.  It
+#    specifies the locations from which to load the class definition for
+#    the class specified by the javaClassName attribute.  Each value of
+#    the attribute contains an ordered list of URLs, separated by spaces.
+#    For example, a value of "url1 url2 url3" means that the three
+#    (possibly interdependent) URLs (url1, url2, and url3) form the
+#    codebase for loading in the Java class definition.
+# 
+#    If the javaCodebase attribute contains more than one value, each
+#    value is an independent codebase. That is, there is no relationship
+#    between the URLs in one value and those in another; each value can be
+#    viewed as an alternate source for loading the Java class definition.
+#    See [Java] for information regarding class loading.
+# 
+#    This attribute's syntax is 'IA5 String' and its case is significant.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.7
+#          NAME 'javaCodebase'
+#          DESC 'URL(s) specifying the location of class definition'
+#          EQUALITY caseExactIA5Match
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+#        )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.7
+	NAME 'javaCodebase'
+	DESC 'URL(s) specifying the location of class definition'
+	EQUALITY caseExactIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 3.3 javaClassNames
+# 
+#    This attribute stores the Java object's fully qualified class or
+#    interface names (for example, "java.lang.String").  It is a
+#    multivalued attribute. When more than one value is present, each is
+#    the name of a class or interface, or ancestor class or interface, of
+#    this object.
+# 
+#    This attribute's syntax is 'Directory String' and its case is
+#    significant.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.13
+#          NAME 'javaClassNames'
+#          DESC 'Fully qualified Java class or interface name'
+#          EQUALITY caseExactMatch
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+#        )
+# 
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.13
+	NAME 'javaClassNames'
+	DESC 'Fully qualified Java class or interface name'
+	EQUALITY caseExactMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+ 
+# 3.4 javaSerializedData
+# 
+#    This attribute stores the serialized form of a Java object.  The
+#    serialized form is described in [Serial].
+# 
+#    This attribute's syntax is 'Octet String'.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.8
+#          NAME 'javaSerializedData
+#          DESC 'Serialized form of a Java object'
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+#          SINGLE-VALUE
+#        )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.8
+	NAME 'javaSerializedData'
+	DESC 'Serialized form of a Java object'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+	SINGLE-VALUE )
+
+# 3.5 javaFactory
+# 
+#    This attribute stores the fully qualified class name of the object
+#    factory (for example, "com.wiz.jndi.WizObjectFactory") that can be
+#    used to create an instance of the object identified by the
+#    javaClassName attribute.
+# 
+#    This attribute's syntax is 'Directory String' and its case is
+#    significant.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.10
+#          NAME 'javaFactory'
+#          DESC 'Fully qualified Java class name of a JNDI object factory'
+#          EQUALITY caseExactMatch
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+#          SINGLE-VALUE
+#        )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.10
+	NAME 'javaFactory'
+	DESC 'Fully qualified Java class name of a JNDI object factory'
+	EQUALITY caseExactMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE )
+
+# 3.6 javaReferenceAddress
+# 
+#    This attribute represents the sequence of addresses of a JNDI
+#    reference.  Each of its values represents one address, a Java object
+#    of type javax.naming.RefAddr.  Its value is a concatenation of the
+#    address type and address contents, preceded by a sequence number (the
+#    order of addresses in a JNDI reference is significant).  For example:
+# 
+#        #0#TypeA#ValA
+#        #1#TypeB#ValB
+#        #2#TypeC##rO0ABXNyABpq...
+# 
+#    In more detail, the value is encoded as follows:
+# 
+#    The delimiter is the first character of the value.  For readability
+#    the character '#' is recommended when it is not otherwise used
+#    anywhere in the value, but any character may be used subject to
+#    restrictions given below.
+# 
+#    The first delimiter is followed by the sequence number.  The sequence
+#    number of an address is its position in the JNDI reference, with the
+#    first address being numbered 0.  It is represented by its shortest
+#    string form, in decimal notation.
+# 
+#    The sequence number is followed by a delimiter, then by the address
+#    type, and then by another delimiter.  If the address is of Java class
+#    javax.naming.StringRefAddr, then this delimiter is followed by the
+#    value of the address contents (which is a string).  Otherwise, this
+#    delimiter is followed immediately by another delimiter, and then by
+#    the Base64 encoding of the serialized form of the entire address.
+# 
+#    The delimiter may be any character other than a digit or a character
+#    contained in the address type.  In addition, if the address contents
+#    is a string, the delimiter may not be the first character of that
+#    string.
+# 
+#    This attribute's syntax is 'Directory String' and its case is
+#    significant.  It can contain multiple values.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.11
+#          NAME 'javaReferenceAddress'
+#          DESC 'Addresses associated with a JNDI Reference'
+#          EQUALITY caseExactMatch
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+#        )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.11
+	NAME 'javaReferenceAddress'
+	DESC 'Addresses associated with a JNDI Reference'
+	EQUALITY caseExactMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+# 3.7 javaDoc
+# 
+#    This attribute stores a pointer to the Java documentation for the
+#    class.  It's value is a URL. For example, the following URL points to
+#    the specification of the java.lang.String class:
+#    http://java.sun.com/products/jdk/1.2/docs/api/java/lang/String.html
+# 
+#    This attribute's syntax is 'IA5 String' and its case is significant.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.1.12
+#          NAME 'javaDoc'
+#          DESC 'The Java documentation for the class'
+#          EQUALITY caseExactIA5Match
+#          SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+#        )
+# 
+attributetype ( 1.3.6.1.4.1.42.2.27.4.1.12
+	NAME 'javaDoc'
+	DESC 'The Java documentation for the class'
+	EQUALITY caseExactIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+# 4 Object Class Definitions
+# 
+#    The following object classes are defined in this document:
+# 
+#        javaContainer
+#        javaObject
+#        javaSerializedObject
+#        javaMarshalledObject
+#        javaNamingReference
+# 
+# 4.1 javaContainer
+# 
+#    This structural object class represents a container for a Java
+#    object.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.2.1
+#          NAME 'javaContainer'
+#          DESC 'Container for a Java object'
+#          SUP top
+#          STRUCTURAL
+#          MUST ( cn )
+#        )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.1
+	NAME 'javaContainer'
+	DESC 'Container for a Java object'
+	SUP top
+	STRUCTURAL
+	MUST cn )
+
+# 4.2 javaObject
+# 
+#    This abstract object class represents a Java object.  A javaObject
+#    cannot exist in the directory; only auxiliary or structural
+#    subclasses of it can exist in the directory.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.2.4
+#          NAME 'javaObject'
+#          DESC 'Java object representation'
+#          SUP top
+#          ABSTRACT
+#          MUST ( javaClassName )
+#          MAY ( javaClassNames $
+#                javaCodebase $
+#                javaDoc $
+#                description )
+#        )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.4
+	NAME 'javaObject'
+	DESC 'Java object representation'
+	SUP top
+	ABSTRACT
+	MUST javaClassName
+	MAY ( javaClassNames $ javaCodebase $
+		javaDoc $ description ) )
+
+# 4.3 javaSerializedObject
+# 
+#    This auxiliary object class represents a Java serialized object.  It
+#    must be mixed in with a structural object class.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.2.5
+#          NAME 'javaSerializedObject'
+#          DESC 'Java serialized object'
+#          SUP javaObject
+#          AUXILIARY
+#          MUST ( javaSerializedData )
+#        )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.5
+	NAME 'javaSerializedObject'
+	DESC 'Java serialized object'
+	SUP javaObject
+	AUXILIARY
+	MUST javaSerializedData )
+ 
+# 4.4 javaMarshalledObject
+# 
+#    This auxiliary object class represents a Java marshalled object.  It
+#    must be mixed in with a structural object class.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.2.8
+#          NAME 'javaMarshalledObject'
+#          DESC 'Java marshalled object'
+#          SUP javaObject
+#          AUXILIARY
+#          MUST ( javaSerializedData )
+#        )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.8
+	NAME 'javaMarshalledObject'
+	DESC 'Java marshalled object'
+	SUP javaObject
+	AUXILIARY
+	MUST javaSerializedData )
+
+# 4.5 javaNamingReference
+# 
+#    This auxiliary object class represents a JNDI reference.  It must be
+#    mixed in with a structural object class.
+# 
+#        ( 1.3.6.1.4.1.42.2.27.4.2.7
+#          NAME 'javaNamingReference'
+#          DESC 'JNDI reference'
+#          SUP javaObject
+#          AUXILIARY
+#          MAY ( javaReferenceAddress $
+#                javaFactory )
+#        )
+# 
+objectclass ( 1.3.6.1.4.1.42.2.27.4.2.7
+	NAME 'javaNamingReference'
+	DESC 'JNDI reference'
+	SUP javaObject
+	AUXILIARY
+	MAY ( javaReferenceAddress $ javaFactory ) )
+ 
+# Full Copyright Statement
+# 
+#    Copyright (C) The Internet Society (1999).  All Rights Reserved.
+# 
+#    This document and translations of it may be copied and furnished to
+#    others, and derivative works that comment on or otherwise explain it
+#    or assist in its implementation may be prepared, copied, published
+#    and distributed, in whole or in part, without restriction of any
+#    kind, provided that the above copyright notice and this paragraph are
+#    included on all such copies and derivative works.  However, this
+#    document itself may not be modified in any way, such as by removing
+#    the copyright notice or references to the Internet Society or other
+#    Internet organizations, except as needed for the purpose of
+#    developing Internet standards in which case the procedures for
+#    copyrights defined in the Internet Standards process must be
+#    followed, or as required to translate it into languages other than
+#    English.
+# 
+#    The limited permissions granted above are perpetual and will not be
+#    revoked by the Internet Society or its successors or assigns.
+# 
+#    This document and the information contained herein is provided on an
+#    "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+#    TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+#    BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+#    HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+#    MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.

--- a/scripts/docker/auth/openldap/schema/microsoftattributetype.schema
+++ b/scripts/docker/auth/openldap/schema/microsoftattributetype.schema
@@ -1,0 +1,5682 @@
+attributetype ( 1.2.840.113556.1.2.447 NAME 'mailNickname'
+        DESC 'MS Exchange alias'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+attributetype ( 1.2.840.113556.1.2.171 NAME 'homeMTA'
+        DESC 'homeMTA'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+attributetype ( 1.2.840.113556.1.2.244 NAME 'homeMDB'
+        DESC 'homeMDB'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+attributetype ( 1.2.840.113556.1.2.309 NAME 'mDBUseDefaults'
+        DESC 'mDBUseDefaults'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.423 NAME 'extensionAttribute1'
+        DESC 'extensionAttribute1'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.528 NAME 'protocolSettings'
+        DESC 'protocolSettings'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.2.551 NAME 'internetEncoding'
+        DESC 'internetEncoding'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1696 NAME 'lastLogonTimestamp'
+        DESC 'lastLogonTimestamp'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.47 NAME 'msExchHomeServerName'
+        DESC 'msExchHomeServerName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.80 NAME 'msExchMailboxSecurityDescriptor'
+        DESC 'msExchMailboxSecurityDescriptor'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.101 NAME 'msExchUserAccountControl'
+        DESC 'msExchUserAccountControl'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.11058 NAME 'msExchMailboxGuid'
+        DESC 'msExchMailboxGuid'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50050 NAME 'msExchPoliciesIncluded'
+        DESC 'msExchPoliciesIncluded'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50341 NAME 'msExchUMDtmfMap'
+        DESC 'msExchUMDtmfMap'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50413 NAME 'msExchMDBRulesQuota'
+        DESC 'msExchMDBRulesQuota'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50730 NAME 'msExchRecipientDisplayType'
+        DESC 'msExchRecipientDisplayType'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50773 NAME 'msExchUserCulture'
+        DESC 'msExchUserCulture'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50853 NAME 'msExchVersion'
+        DESC 'msExchVersion'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50855 NAME 'msExchRecipientTypeDetails'
+        DESC 'msExchRecipientTypeDetails'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50905 NAME 'msExchUMEnabledFlags2'
+        DESC 'msExchUMEnabledFlags2'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50972 NAME 'msExchModerationFlags'
+        DESC 'msExchModerationFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51025 NAME 'msExchTransportRecipientSettingsFlags'
+        DESC 'msExchTransportRecipientSettingsFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51143 NAME 'msExchProvisioningFlags'
+        DESC 'msExchProvisioningFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51383 NAME 'msExchTextMessagingState'
+        DESC 'msExchTextMessagingState'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51429 NAME 'msExchRBACPolicyLink'
+        DESC 'msExchRBACPolicyLink'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51442 NAME 'msExchArchiveQuota'
+        DESC 'msExchArchiveQuota'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51493 NAME 'msExchArchiveWarnQuota'
+        DESC 'msExchArchiveWarnQuota'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51508 NAME 'msExchDumpsterQuota'
+        DESC 'msExchDumpsterQuota'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51509 NAME 'msExchDumpsterWarningQuota'
+        DESC 'msExchDumpsterWarningQuota'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51580 NAME 'msExchWhenMailboxCreated'
+        DESC 'msExchWhenMailboxCreated'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51671 NAME 'msExchMailboxAuditEnable'
+        DESC 'msExchMailboxAuditEnable'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51672 NAME 'msExchMailboxAuditLogAgeLimit'
+        DESC 'msExchMailboxAuditLogAgeLimit'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51678 NAME 'msExchBypassAudit'
+        DESC 'msExchBypassAudit'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51733 NAME 'msExchAddressBookFlags'
+        DESC 'msExchAddressBookFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1710 NAME 'msDS-AllowedDNSSuffixes'
+        DESC 'msDS-AllowedDNSSuffixes'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50765 NAME 'msExchSafeSendersHash'
+        DESC 'msExchSafeSendersHash'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50858 NAME 'msExchMobileMailboxFlags'
+        DESC 'msExchMobileMailboxFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51757 NAME 'msExchObjectsDeletedThisPeriod'
+        DESC 'msExchObjectsDeletedThisPeriod'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.294 NAME 'altRecipientBL'
+        DESC 'altRecipientBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.2.290 NAME 'authOrigBL'
+        DESC 'authOrigBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.1963 NAME 'msDS-SupportedEncryptionTypes'
+        DESC 'msDS-SupportedEncryptionTypes'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.59 NAME 'msExchALObjectVersion'
+        DESC 'msExchALObjectVersion'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51438 NAME 'msExchMailboxMoveBatchName'
+        DESC 'msExchMailboxMoveBatchName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51400 NAME 'msExchMailboxMoveFlags'
+        DESC 'msExchMailboxMoveFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51401 NAME 'msExchMailboxMoveStatus'
+        DESC 'msExchMailboxMoveStatus'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51398 NAME 'msExchMailboxMoveTargetMDBLink'
+        DESC 'msExchMailboxMoveTargetMDBLink'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50976 NAME 'msExchBlockedSendersHash'
+        DESC 'msExchBlockedSendersHash'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50051 NAME 'msExchPoliciesExcluded'
+        DESC 'msExchPoliciesExcluded'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51538 NAME 'msExchDelegateListBL'
+        DESC 'msExchDelegateListBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.2.126 NAME 'altRecipient'
+        DESC 'altRecipient'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.73 NAME 'msExchHideFromAddressLists'
+        DESC 'msExchHideFromAddressLists'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.6.20.1.124 NAME 'msExchOmaAdminWirelessEnable'
+        DESC 'msExchOmaAdminWirelessEnable'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51707 NAME 'msExchShadowProxyAddresses'
+        DESC 'msExchShadowProxyAddresses'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50954 NAME 'msExchCoManagedObjectsBL'
+        DESC 'msExchCoManagedObjectsBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.2.272 NAME 'mDBOverQuotaLimit'
+        DESC 'mDBOverQuotaLimit'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.11037 NAME 'mDBOverHardQuotaLimit'
+        DESC 'mDBOverHardQuotaLimit'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.266 NAME 'mDBStorageQuota'
+        DESC 'mDBStorageQuota'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50766 NAME 'msExchSafeRecipientsHash'
+        DESC 'msExchSafeRecipientsHash'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51152 NAME 'msExchBypassModerationBL'
+        DESC 'msExchBypassModerationBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51698 NAME 'msExchShadowMailNickname'
+        DESC 'msExchShadowMailNickname'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.2.238 NAME 'publicDelegates'
+        DESC 'publicDelegates'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.2.295 NAME 'publicDelegatesBL'
+        DESC 'publicDelegatesBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51608 NAME 'msExchLastExchangeChangedTime'
+        DESC 'msExchLastExchangeChangedTime'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51694 NAME 'msExchShadowGivenName'
+        DESC 'msExchShadowGivenName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51747 NAME 'msExchShadowManagerLink'
+        DESC 'msExchShadowManagerLink'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.5062 NAME 'msExchRequireAuthToSendTo'
+        DESC 'msExchRequireAuthToSendTo'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.432 NAME 'extensionAttribute10'
+        DESC 'extensionAttribute10'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.81 NAME 'msExchMasterAccountSid'
+        DESC 'msExchMasterAccountSid'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.82 NAME 'securityProtocol'
+        DESC 'securityProtocol'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.12527 NAME 'dLMemDefault'
+        DESC 'dLMemDefault'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.138 NAME 'delivContLength'
+        DESC 'delivContLength'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.424 NAME 'extensionAttribute2'
+        DESC 'extensionAttribute2'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.425 NAME 'extensionAttribute3'
+        DESC 'extensionAttribute3'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.426 NAME 'extensionAttribute4'
+        DESC 'extensionAttribute4'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.427 NAME 'extensionAttribute5'
+        DESC 'extensionAttribute5'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.428 NAME 'extensionAttribute6'
+        DESC 'extensionAttribute6'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.429 NAME 'extensionAttribute7'
+        DESC 'extensionAttribute7'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.430 NAME 'extensionAttribute8'
+        DESC 'extensionAttribute8'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.431 NAME 'extensionAttribute9'
+        DESC 'extensionAttribute9'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.371 NAME 'mAPIRecipient'
+        DESC 'mAPIRecipient'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.63 NAME 'msExchADCGlobalNames'
+        DESC 'msExchADCGlobalNames'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.2.444 NAME 'msExchAssistantName'
+        DESC 'msExchAssistantName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.604 NAME 'replicatedObjectVersion'
+        DESC 'replicatedObjectVersion'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.52 NAME 'replicationSignature'
+        DESC 'replicationSignature'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.280 NAME 'submissionContLength'
+        DESC 'submissionContLength'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.79 NAME 'telephoneAssistant'
+        DESC 'telephoneAssistant'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51692 NAME 'msExchShadowDisplayName'
+        DESC 'msExchShadowDisplayName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51708 NAME 'msExchShadowSn'
+        DESC 'msExchShadowSn'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.190 NAME 'deliverAndRedirect'
+        DESC 'deliverAndRedirect'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51530 NAME 'msExchDelegateListLink'
+        DESC 'msExchDelegateListLink'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.2.106 NAME 'deletedItemFlags'
+        DESC 'deletedItemFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51761 NAME 'msExchShadowCompany'
+        DESC 'msExchShadowCompany'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51691 NAME 'msExchShadowDepartment'
+        DESC 'msExchShadowDepartment'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51713 NAME 'msExchShadowTitle'
+        DESC 'msExchShadowTitle'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51705 NAME 'msExchShadowPhysicalDeliveryOfficeName'
+        DESC 'msExchShadowPhysicalDeliveryOfficeName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1993 NAME 'msTSExpireDate'
+        DESC 'msTSExpireDate'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1994 NAME 'msTSLicenseVersion'
+        DESC 'msTSLicenseVersion'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1995 NAME 'msTSManagingLS'
+        DESC 'msTSManagingLS'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51690 NAME 'msExchShadowCountryCode'
+        DESC 'msExchShadowCountryCode'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.287 NAME 'autoReplyMessage'
+        DESC 'autoReplyMessage'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50761 NAME 'msExchELCMailboxFlags'
+        DESC 'msExchELCMailboxFlags'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51762 NAME 'msExchShadowInitials'
+        DESC 'msExchShadowInitials'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51699 NAME 'msExchShadowMobile'
+        DESC 'msExchShadowMobile'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50955 NAME 'msExchModeratedObjectsBL'
+        DESC 'msExchModeratedObjectsBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51260 NAME 'msExchUserBL'
+        DESC 'msExchUserBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.1459 NAME 'msDS-Behavior-Version'
+        DESC 'msDS-Behavior-Version'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.2061 NAME 'msDS-EnabledFeature'
+        DESC 'msDS-EnabledFeature'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.2055 NAME 'msDS-USNLastSyncSuccess'
+        DESC 'msDS-USNLastSyncSuccess'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50004 NAME 'msExchPolicyList'
+        DESC 'msExchPolicyList'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.2.330 NAME 'dLMemberRule'
+        DESC 'dLMemberRule'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        )
+
+attributetype ( 1.2.840.113556.1.2.297 NAME 'hideDLMembership'
+        DESC 'hideDLMembership'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1819 NAME 'msDS-AzApplicationData'
+        DESC 'msDS-AzApplicationData'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1801 NAME 'msDS-AzBizRule'
+        DESC 'msDS-AzBizRule'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1802 NAME 'msDS-AzBizRuleLanguage'
+        DESC 'msDS-AzBizRuleLanguage'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1950 NAME 'msDS-AzGenericData'
+        DESC 'msDS-AzGenericData'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1792 NAME 'msDS-AzLDAPQuery'
+        DESC 'msDS-AzLDAPQuery'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1803 NAME 'msDS-AzLastImportedBizRulePath'
+        DESC 'msDS-AzLastImportedBizRulePath'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1949 NAME 'msDS-AzObjectGuid'
+        DESC 'msDS-AzObjectGuid'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1997 NAME 'msDS-HABSeniorityIndex'
+        DESC 'msDS-HABSeniorityIndex'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1793 NAME 'msDS-NonMembers'
+        DESC 'msDS-NonMembers'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.1946 NAME 'msDS-PhoneticDisplayName'
+        DESC 'msDS-PhoneticDisplayName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50957 NAME 'msExchArbitrationMailbox'
+        DESC 'msExchArbitrationMailbox'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50953 NAME 'msExchCoManagedByLink'
+        DESC 'msExchCoManagedByLink'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50964 NAME 'msExchGroupDepartRestriction'
+        DESC 'msExchGroupDepartRestriction'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50963 NAME 'msExchGroupJoinRestriction'
+        DESC 'msExchGroupJoinRestriction'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50835 NAME 'msExchMasterAccountHistory'
+        DESC 'msExchMasterAccountHistory'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50300 NAME 'msExchOriginatingForest'
+        DESC 'msExchOriginatingForest'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50640 NAME 'msExchServerAdminDelegationBL'
+        DESC 'msExchServerAdminDelegationBL'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.6.47.2.3 NAME 'msOrg-GroupSubtypeName'
+        DESC 'msOrg-GroupSubtypeName'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.6.47.2.1 NAME 'msOrg-IsOrganizational'
+        DESC 'msOrg-IsOrganizational'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.6.47.2.2 NAME 'msOrg-Leaders'
+        DESC 'msOrg-Leaders'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        )
+
+attributetype ( 1.2.840.113556.1.6.47.2.4 NAME 'msOrg-OtherDisplayNames'
+        DESC 'msOrg-OtherDisplayNames'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        )
+
+attributetype ( 1.2.840.113556.1.6.18.1.309 NAME 'msSFU30Name'
+        DESC 'msSFU30Name'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.6.18.1.339 NAME 'msSFU30NisDomain'
+        DESC 'msSFU30NisDomain'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.6.18.1.346 NAME 'msSFU30PosixMember'
+        DESC 'msSFU30PosixMember'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.438 NAME 'oOFReplyToOriginator'
+        DESC 'oOFReplyToOriginator'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.206 NAME 'reportToOriginator'
+        DESC 'reportToOriginator'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.207 NAME 'reportToOwner'
+        DESC 'reportToOwner'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.4.1879 NAME 'msDS-SourceObjectDN'
+        DESC 'msDS-SourceObjectDN'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+attributetype ( 1.2.840.113556.1.2.352 NAME 'targetAddress'
+        DESC 'targetAddress'
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE
+        )
+
+# 1.3.6.1.4.1.250.1.57 -> 1.3.6.1.4.1.250.1.57.0 clash with OpenLdap
+attributetype ( 1.3.6.1.4.1.250.1.57.0
+ NAME 'DUP-labeledURI-e20b3d32-5a2b-4f6c-84c0-65c94ba52437'
+ DESC 'DUP-labeledURI-e20b3d32-5a2b-4f6c-84c0-65c94ba52437'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+# 0.9.2342.19200300.100.1.21 -> 0.9.2342.19200300.100.1.21.0 clash with OpenLdap
+attributetype ( 0.9.2342.19200300.100.1.21.0
+ NAME 'DUP-secretary-00efea41-cee1-4f20-b9c3-a2a93ec60616'
+ DESC 'DUP-secretary-00efea41-cee1-4f20-b9c3-a2a93ec60616'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.129
+ NAME 'authOrig'
+ DESC 'authOrig'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.2.47
+ NAME 'dLMemRejectPerms'
+ DESC 'dLMemRejectPerms'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
+  )
+
+attributetype ( 1.2.840.113556.1.2.293
+ NAME 'dLMemRejectPermsBL'
+ DESC 'dLMemRejectPermsBL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.144
+ NAME 'dLMemSubmitPerms'
+ DESC 'dLMemSubmitPerms'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.2.291
+ NAME 'dLMemSubmitPermsBL'
+ DESC 'dLMemSubmitPermsBL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.140
+ NAME 'delivExtContTypes'
+ DESC 'delivExtContTypes'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.2.241
+ NAME 'deliveryMechanism'
+ DESC 'deliveryMechanism'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.474
+ NAME 'enabledProtocols'
+ DESC 'enabledProtocols'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.394
+ NAME 'expirationTime'
+ DESC 'expirationTime'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.228
+ NAME 'extensionData'
+ DESC 'extensionData'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.2.337
+ NAME 'folderPathname'
+ DESC 'folderPathname'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.607
+ NAME 'formData'
+ DESC 'formData'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.606
+ NAME 'forwardingAddress'
+ DESC 'forwardingAddress'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.263
+ NAME 'importedFrom'
+ DESC 'importedFrom'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.616
+ NAME 'language'
+ DESC 'language'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.467
+ NAME 'languageCode'
+ DESC 'languageCode'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51149
+ NAME 'msExchAggregationSubscriptionCredential'
+ DESC 'msExchAggregationSubscriptionCredential'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51673
+ NAME 'msExchAuditAdmin'
+ DESC 'msExchAuditAdmin'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51674
+ NAME 'msExchAuditDelegate'
+ DESC 'msExchAuditDelegate'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51675
+ NAME 'msExchAuditDelegateAdmin'
+ DESC 'msExchAuditDelegateAdmin'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51676
+ NAME 'msExchAuditOwner'
+ DESC 'msExchAuditOwner'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51151
+ NAME 'msExchBypassModerationFromDLMembersBL'
+ DESC 'msExchBypassModerationFromDLMembersBL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51141
+ NAME 'msExchBypassModerationFromDLMembersLink'
+ DESC 'msExchBypassModerationFromDLMembersLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51140
+ NAME 'msExchBypassModerationLink'
+ DESC 'msExchBypassModerationLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51754
+ NAME 'msExchCalculatedTargetAddress'
+ DESC 'msExchCalculatedTargetAddress'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51336
+ NAME 'msExchCalendarRepairDisabled'
+ DESC 'msExchCalendarRepairDisabled'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51581
+ NAME 'msExchCapabilityIdentifiers'
+ DESC 'msExchCapabilityIdentifiers'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50049
+ NAME 'msExchCustomProxyAddresses'
+ DESC 'msExchCustomProxyAddresses'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51414
+ NAME 'msExchDirsyncID'
+ DESC 'msExchDirsyncID'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51746
+ NAME 'msExchDirsyncSourceObjectClass'
+ DESC 'msExchDirsyncSourceObjectClass'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51506
+ NAME 'msExchEdgeSyncRetryCount'
+ DESC 'msExchEdgeSyncRetryCount'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50969
+ NAME 'msExchEnableModeration'
+ DESC 'msExchEnableModeration'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51577
+ NAME 'msExchEwsApplicationAccessPolicy'
+ DESC 'msExchEwsApplicationAccessPolicy'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51571
+ NAME 'msExchEwsEnabled'
+ DESC 'msExchEwsEnabled'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51573
+ NAME 'msExchEwsExceptions'
+ DESC 'msExchEwsExceptions'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51576
+ NAME 'msExchEwsWellKnownApplicationPolicies'
+ DESC 'msExchEwsWellKnownApplicationPolicies'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.49
+ NAME 'msExchExpansionServerName'
+ DESC 'msExchExpansionServerName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51032
+ NAME 'msExchExternalSyncState'
+ DESC 'msExchExternalSyncState'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.10001
+ NAME 'msExchFBURL'
+ DESC 'msExchFBURL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51561
+ NAME 'msExchForeignGroupSID'
+ DESC 'msExchForeignGroupSID'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51620
+ NAME 'msExchGenericForwardingAddress'
+ DESC 'msExchGenericForwardingAddress'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50823
+ NAME 'msExchHABShowInDepartments'
+ DESC 'msExchHABShowInDepartments'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51022
+ NAME 'msExchImmutableId'
+ DESC 'msExchImmutableId'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51563
+ NAME 'msExchIntendedMailboxPlanLink'
+ DESC 'msExchIntendedMailboxPlanLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51677
+ NAME 'msExchInterruptUserOnAuditFailure'
+ DESC 'msExchInterruptUserOnAuditFailure'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.593
+ NAME 'msExchLabeledURI'
+ DESC 'msExchLabeledURI'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51570
+ NAME 'msExchLicenseToken'
+ DESC 'msExchLicenseToken'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51734
+ NAME 'msExchLitigationHoldDate'
+ DESC 'msExchLitigationHoldDate'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51735
+ NAME 'msExchLitigationHoldOwner'
+ DESC 'msExchLitigationHoldOwner'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51738
+ NAME 'msExchMailboxAuditLastAdminAccess'
+ DESC 'msExchMailboxAuditLastAdminAccess'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51739
+ NAME 'msExchMailboxAuditLastDelegateAccess'
+ DESC 'msExchMailboxAuditLastDelegateAccess'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51737
+ NAME 'msExchMailboxAuditLastExternalAccess'
+ DESC 'msExchMailboxAuditLastExternalAccess'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.11091
+ NAME 'msExchMailboxFolderSet'
+ DESC 'msExchMailboxFolderSet'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51568
+ NAME 'msExchMailboxFolderSet2'
+ DESC 'msExchMailboxFolderSet2'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51402
+ NAME 'msExchMailboxMoveRemoteHostName'
+ DESC 'msExchMailboxMoveRemoteHostName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51684
+ NAME 'msExchMailboxMoveSourceArchiveMDBLink'
+ DESC 'msExchMailboxMoveSourceArchiveMDBLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51439
+ NAME 'msExchMailboxMoveSourceMDBLink'
+ DESC 'msExchMailboxMoveSourceMDBLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51685
+ NAME 'msExchMailboxMoveTargetArchiveMDBLink'
+ DESC 'msExchMailboxMoveTargetArchiveMDBLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51405
+ NAME 'msExchMailboxPlanType'
+ DESC 'msExchMailboxPlanType'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50687
+ NAME 'msExchMessageHygieneFlags'
+ DESC 'msExchMessageHygieneFlags'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50779
+ NAME 'msExchMessageHygieneSCLDeleteThreshold'
+ DESC 'msExchMessageHygieneSCLDeleteThreshold'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50783
+ NAME 'msExchMessageHygieneSCLJunkThreshold'
+ DESC 'msExchMessageHygieneSCLJunkThreshold'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50781
+ NAME 'msExchMessageHygieneSCLQuarantineThreshold'
+ DESC 'msExchMessageHygieneSCLQuarantineThreshold'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50780
+ NAME 'msExchMessageHygieneSCLRejectThreshold'
+ DESC 'msExchMessageHygieneSCLRejectThreshold'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50952
+ NAME 'msExchModeratedByLink'
+ DESC 'msExchModeratedByLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50993
+ NAME 'msExchOWAPolicy'
+ DESC 'msExchOWAPolicy'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51569
+ NAME 'msExchObjectID'
+ DESC 'msExchObjectID'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51142
+ NAME 'msExchParentPlanLink'
+ DESC 'msExchParentPlanLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51644
+ NAME 'msExchPartnerGroupID'
+ DESC 'msExchPartnerGroupID'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50030
+ NAME 'msExchPolicyEnabled'
+ DESC 'msExchPolicyEnabled'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50006
+ NAME 'msExchPolicyOptionList'
+ DESC 'msExchPolicyOptionList'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.93
+ NAME 'msExchPreviousAccountSid'
+ DESC 'msExchPreviousAccountSid'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50048
+ NAME 'msExchProxyCustomProxy'
+ DESC 'msExchProxyCustomProxy'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51492
+ NAME 'msExchRMSComputerAccountsLink'
+ DESC 'msExchRMSComputerAccountsLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.12523
+ NAME 'msExchRecipLimit'
+ DESC 'msExchRecipLimit'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51611
+ NAME 'msExchRemoteRecipientType'
+ DESC 'msExchRemoteRecipientType'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50332
+ NAME 'msExchResourceCapacity'
+ DESC 'msExchResourceCapacity'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50334
+ NAME 'msExchResourceDisplay'
+ DESC 'msExchResourceDisplay'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50333
+ NAME 'msExchResourceMetaData'
+ DESC 'msExchResourceMetaData'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50331
+ NAME 'msExchResourceSearchProperties'
+ DESC 'msExchResourceSearchProperties'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51240
+ NAME 'msExchRetentionComment'
+ DESC 'msExchRetentionComment'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51242
+ NAME 'msExchRetentionURL'
+ DESC 'msExchRetentionURL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51150
+ NAME 'msExchSendAsAddresses'
+ DESC 'msExchSendAsAddresses'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50899
+ NAME 'msExchSenderHintTranslations'
+ DESC 'msExchSenderHintTranslations'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51624
+ NAME 'msExchSharingAnonymousIdentities'
+ DESC 'msExchSharingAnonymousIdentities'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51031
+ NAME 'msExchSharingPartnerIdentities'
+ DESC 'msExchSharingPartnerIdentities'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51266
+ NAME 'msExchSharingPolicyLink'
+ DESC 'msExchSharingPolicyLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50990
+ NAME 'msExchSignupAddresses'
+ DESC 'msExchSignupAddresses'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51366
+ NAME 'msExchSupervisionDLLink'
+ DESC 'msExchSupervisionDLLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51367
+ NAME 'msExchSupervisionOneOffLink'
+ DESC 'msExchSupervisionOneOffLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51365
+ NAME 'msExchSupervisionUserLink'
+ DESC 'msExchSupervisionUserLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51394
+ NAME 'msExchSyncAccountsPolicyDN'
+ DESC 'msExchSyncAccountsPolicyDN'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51096
+ NAME 'msExchThrottlingPolicyDN'
+ DESC 'msExchThrottlingPolicyDN'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51612
+ NAME 'msExchUCVoiceMailSettings'
+ DESC 'msExchUCVoiceMailSettings'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51344
+ NAME 'msExchUMAddresses'
+ DESC 'msExchUMAddresses'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51145
+ NAME 'msExchUMCallingLineIDs'
+ DESC 'msExchUMCallingLineIDs'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50342
+ NAME 'msExchUMListInDirectorySearch'
+ DESC 'msExchUMListInDirectorySearch'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50388
+ NAME 'msExchUMRecipientDialPlanLink'
+ DESC 'msExchUMRecipientDialPlanLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50336
+ NAME 'msExchUMSpokenName'
+ DESC 'msExchUMSpokenName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51767
+ NAME 'msExchUsageLocation'
+ DESC 'msExchUsageLocation'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.51016
+ NAME 'msExchWindowsLiveID'
+ DESC 'msExchWindowsLiveID'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.468
+ NAME 'pOPCharacterSet'
+ DESC 'pOPCharacterSet'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.466
+ NAME 'pOPContentFormat'
+ DESC 'pOPContentFormat'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.223
+ NAME 'replicationSensitivity'
+ DESC 'replicationSensitivity'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.221
+ NAME 'unauthOrig'
+ DESC 'unauthOrig'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
+  )
+
+attributetype ( 1.2.840.113556.1.2.292
+ NAME 'unauthOrigBL'
+ DESC 'unauthOrigBL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50351
+ NAME 'msExchMailboxTemplateLink'
+ DESC 'msExchMailboxTemplateLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.7031
+ NAME 'msExchIMACL'
+ DESC 'msExchIMACL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.7038
+ NAME 'msExchIMAddress'
+ DESC 'msExchIMAddress'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.7035
+ NAME 'msExchIMMetaPhysicalURL'
+ DESC 'msExchIMMetaPhysicalURL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.7036
+ NAME 'msExchIMPhysicalURL'
+ DESC 'msExchIMPhysicalURL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.7037
+ NAME 'msExchIMVirtualServer'
+ DESC 'msExchIMVirtualServer'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50668
+ NAME 'msExchMobileMailboxPolicyLink'
+ DESC 'msExchMobileMailboxPolicyLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.63.1000.1.1.1.1.16
+ NAME 'apple-mcxsettings'
+ DESC 'apple-mcxsettings'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.48
+ NAME 'unmergedAtts'
+ DESC 'unmergedAtts'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.50666
+ NAME 'msExchMobileAllowedDeviceIDs'
+ DESC 'msExchMobileAllowedDeviceIDs'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.2.348
+ NAME 'logRolloverInterval'
+ DESC 'logRolloverInterval'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  )
+
+attributetype ( 1.2.840.113556.1.2.198
+ NAME 'monitoredConfigurations'
+ DESC 'monitoredConfigurations'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.199
+ NAME 'monitoredServices'
+ DESC 'monitoredServices'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.2.450
+ NAME 'monitoringAvailabilityStyle'
+ DESC 'monitoringAvailabilityStyle'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.200
+ NAME 'monitoringAvailabilityWindow'
+ DESC 'monitoringAvailabilityWindow'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.196
+ NAME 'monitoringCachedViaMail'
+ DESC 'monitoringCachedViaMail'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.197
+ NAME 'monitoringCachedViaRPC'
+ DESC 'monitoringCachedViaRPC'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.195
+ NAME 'monitoringMailUpdateInterval'
+ DESC 'monitoringMailUpdateInterval'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.93
+ NAME 'monitoringMailUpdateUnits'
+ DESC 'monitoringMailUpdateUnits'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.92
+ NAME 'monitoringRPCUpdateInterval'
+ DESC 'monitoringRPCUpdateInterval'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.89
+ NAME 'monitoringRPCUpdateUnits'
+ DESC 'monitoringRPCUpdateUnits'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1717
+ NAME 'msDS-AdditionalDnsHostName'
+ DESC 'msDS-AdditionalDnsHostName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.1718
+ NAME 'msDS-AdditionalSamAccountName'
+ DESC 'msDS-AdditionalSamAccountName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.1958
+ NAME 'msDS-AuthenticatedAtDC'
+ DESC 'msDS-AuthenticatedAtDC'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.1783
+ NAME 'msDS-ExecuteScriptPassword'
+ DESC 'msDS-ExecuteScriptPassword'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.2056
+ NAME 'msDS-HostServiceAccount'
+ DESC 'msDS-HostServiceAccount'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.2025
+ NAME 'msDS-IsUserCachableAtRodc'
+ DESC 'msDS-IsUserCachableAtRodc'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1923
+ NAME 'msDS-KrbTgtLink'
+ DESC 'msDS-KrbTgtLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1926
+ NAME 'msDS-NeverRevealGroup'
+ DESC 'msDS-NeverRevealGroup'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.1962
+ NAME 'msDS-PromotionSettings'
+ DESC 'msDS-PromotionSettings'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1928
+ NAME 'msDS-RevealOnDemandGroup'
+ DESC 'msDS-RevealOnDemandGroup'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.1940
+ NAME 'msDS-RevealedList'
+ DESC 'msDS-RevealedList'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  )
+
+attributetype ( 1.2.840.113556.1.4.1924
+ NAME 'msDS-RevealedUsers'
+ DESC 'msDS-RevealedUsers'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.1961
+ NAME 'msDS-SiteName'
+ DESC 'msDS-SiteName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1959
+ NAME 'msDS-isGC'
+ DESC 'msDS-isGC'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1960
+ NAME 'msDS-isRODC'
+ DESC 'msDS-isRODC'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.7000.102.71
+ NAME 'msExchExchangeServerLink'
+ DESC 'msExchExchangeServerLink'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.6.18.1.323
+ NAME 'msSFU30Aliases'
+ DESC 'msSFU30Aliases'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.1966
+ NAME 'msTPM-OwnerInformation'
+ DESC 'msTPM-OwnerInformation'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.2070
+ NAME 'msTSEndpointData'
+ DESC 'msTSEndpointData'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.2072
+ NAME 'msTSEndpointPlugin'
+ DESC 'msTSEndpointPlugin'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.2071
+ NAME 'msTSEndpointType'
+ DESC 'msTSEndpointType'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.2074
+ NAME 'msTSPrimaryDesktopBL'
+ DESC 'msTSPrimaryDesktopBL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.4.1991
+ NAME 'msTSProperty01'
+ DESC 'msTSProperty01'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.1992
+ NAME 'msTSProperty02'
+ DESC 'msTSProperty02'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  )
+
+attributetype ( 1.2.840.113556.1.4.2078
+ NAME 'msTSSecondaryDesktopBL'
+ DESC 'msTSSecondaryDesktopBL'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  )
+
+attributetype ( 1.2.840.113556.1.2.540
+ NAME 'promoExpiration'
+ DESC 'promoExpiration'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.347
+ NAME 'trackingLogPathName'
+ DESC 'trackingLogPathName'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.573
+ NAME 'type'
+ DESC 'type'
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ SINGLE-VALUE )
+
+#---
+
+attributetype ( 1.2.840.113556.1.4.856
+	NAME 'netbootNewMachineOU'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.13
+	NAME 'builtinCreationTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1335
+	NAME 'pKIEnrollmentAccess'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.1333
+	NAME 'pKIExtendedKeyUsage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1123
+	NAME 'msNPCalledStationID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26' )
+
+attributetype ( 1.2.840.113556.1.4.539
+	NAME 'initialAuthIncoming'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.370
+	NAME 'objectClassCategory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.41
+	NAME 'generatedConnection'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.911
+	NAME 'allowedChildClasses'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.68
+	NAME 'machineArchitecture'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.767
+	NAME 'aCSMaxPeakBandwidth'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.72
+	NAME 'marshalledInterface'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.368
+	NAME 'rIDManagerReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.770
+	NAME 'aCSEnableACSService'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1237
+	NAME 'mSMQRoutingService'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1405
+	NAME 'mS-SQL-AllowQueuedUpdatingSubscription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.648
+	NAME 'primaryTelexNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.8
+	NAME 'userAccountControl'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.563
+	NAME 'shellPropertyPages'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.4
+	NAME 'replUpToDateVector'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.484
+	NAME 'fRSDirectoryFilter'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.230
+	NAME 'printSeparatorFile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1329
+	NAME 'pKIMaxIssuingDepth'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1307
+	NAME 'accountNameHistory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1386
+	NAME 'mS-SQL-GPSLongitude'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.562
+	NAME 'adminPropertyPages'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.121
+	NAME 'securityIdentifier'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.166
+	NAME 'groupMembershipSAM'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.659
+	NAME 'serviceDNSNameType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.585
+	NAME 'meetingIsEncrypted'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1400
+	NAME 'mS-SQL-Applications'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.330
+	NAME 'lastUpdateSequence'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.50
+	NAME 'lastContentIndexed'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.567
+	NAME 'meetingDescription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.880
+	NAME 'fRSTimeLastCommand'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.83
+	NAME 'monikerDisplayName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.321
+	NAME 'requiredCategories'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.813
+	NAME 'upgradeProductCode'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.774
+	NAME 'aCSMaxNoOfLogFiles'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1370
+	NAME 'mS-SQL-CharacterSet'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.578
+	NAME 'meetingContactInfo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1397
+	NAME 'mS-SQL-CreationDate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.32
+	NAME 'domainPolicyObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.703
+	NAME 'dhcpObjDescription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.573
+	NAME 'meetingApplication'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.518
+	NAME 'defaultHidingValue'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.875
+	NAME 'fRSMemberReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.701
+	NAME 'dhcpIdentification'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.135
+	NAME 'trustAuthOutgoing'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.197
+	NAME 'systemMustContain'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1412
+	NAME 'primaryGroupToken'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.118
+	NAME 'rpcNsProfileEntry'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.129
+	NAME 'trustAuthIncoming'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1225
+	NAME 'mSMQPrevSiteGates'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.607
+	NAME 'queryPolicyObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.712
+	NAME 'optionDescription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1314
+	NAME 'aCSMaximumSDUSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.530
+	NAME 'nonSecurityMember'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.31
+	NAME 'fRSReplicaSetType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.763
+	NAME 'aCSTotalNoOfFlows'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.915
+	NAME 'possibleInferiors'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.851
+	NAME 'netbootMaxClients'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1385
+	NAME 'mS-SQL-GPSLatitude'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.765
+	NAME 'aCSPermissionBits'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.926
+	NAME 'mSMQTransactional'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1390
+	NAME 'mS-SQL-Description'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.913
+	NAME 'allowedAttributes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.491
+	NAME 'fRSFaultCondition'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.54
+	NAME 'tombstoneLifetime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.809
+	NAME 'remoteStorageGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.644
+	NAME 'showInAddressBook'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.213
+	NAME 'defaultClassStore'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.577
+	NAME 'meetingOriginator'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.656
+	NAME 'userPrincipalName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1316
+	NAME 'aCSMinimumLatency'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.2.617
+#	NAME 'homePostalAddress'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+#
+# Moved to microsoftattributetype.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.29.  Home postal address
+#
+#  The Home postal address attribute type specifies a home postal
+#  address for an object.  This should be limited to up to 6 lines of 30
+#  characters each.
+#
+#    homePostalAddress ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            postalAddress
+#            MATCHES FOR EQUALITY
+#    ::= {pilotAttributeType 39}
+#
+attributetype ( 0.9.2342.19200300.100.1.39 NAME 'homePostalAddress'
+	DESC 'RFC1274: home postal address'
+	EQUALITY caseIgnoreListMatch
+	SUBSTR caseIgnoreListSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 )
+
+
+attributetype ( 1.2.840.113556.1.4.638
+	NAME 'isPrivilegeHolder'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.533
+	NAME 'fRSReplicaSetGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.371
+	NAME 'rIDAllocationPool'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1327
+	NAME 'pKIDefaultKeySpec'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.537
+	NAME 'dynamicLDAPServer'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.516
+	NAME 'serverReferenceBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.500
+	NAME 'fRSServiceCommand'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1304
+	NAME 'sDRightsEffective'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1249
+	NAME 'proxiedObjectName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.586
+	NAME 'meetingRecurrence'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.251
+	NAME 'cOMTreatAsClassId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1245
+	NAME 'globalAddressList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.908
+	NAME 'extendedClassInfo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.459
+	NAME 'machineWidePolicy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.356
+	NAME 'foreignIdentifier'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1242
+	NAME 'dNReferenceUpdate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.134
+	NAME 'trustPosixOffset'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.36
+	NAME 'enabledConnection'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.627
+	NAME 'ipsecNFAReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.86
+	NAME 'userWorkstations'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.301
+	NAME 'garbageCollPeriod'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.933
+	NAME 'mSMQComputerType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.65
+	NAME 'logonWorkstation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.921
+	NAME 'mSMQJournalQuota'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.108
+	NAME 'remoteSourceType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.95
+	NAME 'pwdHistoryLength'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.920
+	NAME 'mSMQBasePriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.196
+	NAME 'systemMayContain'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1407
+	NAME 'mS-SQL-ThirdParty'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1243
+	NAME 'mSMQQueueNameExt'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.485
+	NAME 'fRSUpdateTimeout'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.924
+	NAME 'mSMQPrivacyLevel'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.615
+	NAME 'shellContextMenu'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.618
+	NAME 'wellKnownObjects'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.789
+	NAME 'transportDLLName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.458
+	NAME 'qualityOfService'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.73
+	NAME 'lockoutThreshold'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.105
+	NAME 'remoteServerName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.694
+	NAME 'previousParentCA'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.1345
+	NAME 'dSUIShellMaximum'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.303
+	NAME 'notificationList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1244
+	NAME 'addressBookRoots'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.878
+	NAME 'fRSPrimaryMember'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.587
+	NAME 'meetingStartTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24' )
+
+attributetype ( 1.2.840.113556.1.4.1310
+	NAME 'mSMQSiteGatesMig'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.709
+	NAME 'dhcpReservations'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.614
+	NAME 'adminContextMenu'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1332
+	NAME 'pKIOverlapPeriod'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.142
+	NAME 'winsockAddresses'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.923
+	NAME 'mSMQAuthenticate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1344
+	NAME 'dSUIAdminMaximum'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.848
+	NAME 'appSchemaVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.123
+	NAME 'serviceClassInfo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.769
+	NAME 'aCSEventLogLevel'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.751
+	NAME 'userSharedFolder'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.421
+	NAME 'domainWidePolicy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.669
+	NAME 'rIDSetReferences'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.815
+	NAME 'canUpgradeScript'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.610
+	NAME 'classDisplayName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.226
+	NAME 'adminDescription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.67
+	NAME 'lSAModifiedCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.509
+	NAME 'serviceClassName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.56
+	NAME 'localPolicyFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.115
+	NAME 'rpcNsInterfaceID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.194
+	NAME 'adminDisplayName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.753
+	NAME 'nameServiceFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.589
+	NAME 'meetingBandwidth'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.755
+	NAME 'domainIdentifier'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.370
+	NAME 'rIDAvailablePool'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+# Printable String does not support '_'
+#
+#attributetype ( 1.2.840.113556.1.4.655
+#	NAME 'legacyExchangeDN'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+#	SINGLE-VALUE )
+attributetype ( 1.2.840.113556.1.4.655
+	NAME 'legacyExchangeDN'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.470
+	NAME 'trustAttributes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.535
+	NAME 'fRSRootSecurity'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.532
+	NAME 'superiorDNSRoot'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.278
+	NAME 'printMaxYExtent'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.277
+	NAME 'printMaxXExtent'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.280
+	NAME 'printMinYExtent'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.279
+	NAME 'printMinXExtent'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.32
+	NAME 'attributeSyntax'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.247
+	NAME 'printAttributes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.152
+	NAME 'groupAttributes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.816
+	NAME 'fileExtPriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.930
+	NAME 'mSMQServiceType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.363
+	NAME 'operatingSystem'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1371
+	NAME 'mS-SQL-SortOrder'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.329
+	NAME 'versionNumberLo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.884
+	NAME 'msRRASAttribute'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.781
+	NAME 'lastKnownParent'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1209
+	NAME 'shortServerName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.60
+	NAME 'lockoutDuration'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.232
+	NAME 'defaultPriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.754
+	NAME 'rpcNsEntryFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.713
+	NAME 'optionsLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.328
+	NAME 'versionNumberHi'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.366
+	NAME 'rpcNsAnnotation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.886
+	NAME 'purportedSearch'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.776
+	NAME 'aCSDSBMPriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.961
+	NAME 'mSMQSiteForeign'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7' )
+
+attributetype ( 1.2.840.113556.1.4.335
+	NAME 'currentLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.570
+	NAME 'meetingProtocol'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.420
+	NAME 'publicKeyPolicy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1402
+	NAME 'mS-SQL-Publisher'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.812
+	NAME 'createWizardExt'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1373
+	NAME 'mS-SQL-Clustered'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.334
+	NAME 'volTableIdxGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.696
+	NAME 'currentParentCA'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.504
+	NAME 'seqNotification'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.515
+	NAME 'serverReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1119
+	NAME 'msNPAllowDialin'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1387
+	NAME 'mS-SQL-GPSHeight'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1378
+	NAME 'mS-SQL-AppleTalk'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.269
+	NAME 'linkTrackSecret'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.378
+	NAME 'dnsAllowDynamic'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.49
+	NAME 'badPasswordTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.637
+	NAME 'privilegeHolder'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.289
+	NAME 'printMediaReady'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.288
+	NAME 'printMACAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.66
+	NAME 'lSACreationTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.569
+	NAME 'meetingLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.784
+	NAME 'aCSIdentityName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1410
+	NAME 'mS-DS-CreatorSID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1374
+	NAME 'mS-SQL-NamedPipe'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.843
+	NAME 'lDAPAdminLimits'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.460
+	NAME 'lDAPDisplayName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.218
+	NAME 'applicationName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.695
+	NAME 'pendingParentCA'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.779
+	NAME 'aCSCacheTimeout'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.574
+	NAME 'meetingLanguage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.778
+	NAME 'aCSDSBMDeadTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.697
+	NAME 'cACertificateDN'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.138
+	NAME 'userParameters'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.132
+	NAME 'trustDirection'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.962
+	NAME 'mSMQQueueQuota'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.936
+	NAME 'mSMQEncryptKey'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.885
+	NAME 'terminalServer'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.233
+	NAME 'printStartTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.664
+	NAME 'syncWithObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.344
+	NAME 'groupsToIgnore'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.665
+	NAME 'syncMembership'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.666
+	NAME 'syncAttributes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.214
+	NAME 'nextLevelStore'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.302
+	NAME 'sAMAccountType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1401
+	NAME 'mS-SQL-Keywords'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.210 NAME 'proxyAddresses'
+        DESC 'rfc822 mail address of group member(s)'
+        EQUALITY caseIgnoreIA5Match
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+        
+attributetype ( 1.2.840.113556.1.4.284
+	NAME 'bytesPerMinute'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.241
+	NAME 'printMaxCopies'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.98
+	NAME 'primaryGroupID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.89
+	NAME 'nTGroupMembers'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.1228
+	NAME 'mSMQDsServices'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.43
+	NAME 'fRSVersionGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.486
+	NAME 'fRSWorkingPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.18
+	NAME 'otherTelephone'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.277
+	NAME 'otherHomePhone'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.151
+	NAME 'oEMInformation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.459
+	NAME 'networkAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.966
+	NAME 'mSMQDigestsMig'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.568
+	NAME 'meetingKeyword'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.844
+	NAME 'lDAPIPDenyList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.847
+	NAME 'installUiLevel'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.894
+	NAME 'gPCFileSysPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.488
+	NAME 'fRSStagingPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.351
+	NAME 'auxiliaryClass'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38' )
+
+attributetype ( 1.2.840.113556.1.4.159
+	NAME 'accountExpires'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.718
+	NAME 'dhcpProperties'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.346
+	NAME 'desktopProfile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.762
+	NAME 'aCSServiceType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.2.610
+#	NAME 'employeeNumber'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1213
+	NAME 'assocNTAccount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.498
+	NAME 'creationWizard'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.253
+	NAME 'cOMOtherProgId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.202
+	NAME 'auditingPolicy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.635
+	NAME 'privilegeValue'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1366
+	NAME 'mS-SQL-Location'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1334
+	NAME 'pKIDefaultCSPs'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.270
+	NAME 'printShareName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.33
+	NAME 'isSingleValued'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.472
+	NAME 'domainCrossRef'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1240
+	NAME 'netbootSIFFile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.250
+	NAME 'cOMUniqueLIBID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.657
+	NAME 'serviceDNSName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.782
+        NAME 'objectCategory'
+        EQUALITY distinguishedNameMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.122
+	NAME 'serviceClassID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.720
+	NAME 'dhcpUpdateTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.221
+	NAME 'sAMAccountName'
+    EQUALITY caseIgnoreMatch
+    SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.588
+	NAME 'meetingEndTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24' )
+
+attributetype ( 1.2.840.113556.1.4.1389
+	NAME 'mS-SQL-Language'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.777
+	NAME 'aCSDSBMRefresh'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1393
+	NAME 'mS-SQL-Database'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.20
+	NAME 'cOMInterfaceID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1403
+	NAME 'mS-SQL-AllowKnownPullSubscription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1394
+	NAME 'mS-SQL-AllowAnonymousSubscription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.654
+	NAME 'managedObjects'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.2.8
+	NAME 'possSuperiors'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38' )
+
+attributetype ( 1.2.840.113556.1.4.791
+	NAME 'transportType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.345
+	NAME 'groupPriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.117
+	NAME 'rpcNsPriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.917
+	NAME 'mSMQQueueType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.141
+	NAME 'versionNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.121
+	NAME 'uSNLastObjRem'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1346
+	NAME 'templateRoots'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.93
+	NAME 'pwdProperties'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.290
+	NAME 'printNumberUp'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.536
+	NAME 'fRSExtensions'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.286
+	NAME 'printRateUnit'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.846
+	NAME 'msiScriptSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.274
+	NAME 'printSpooling'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.608
+	NAME 'queryPolicyBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.103
+	NAME 'proxyLifetime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.144
+	NAME 'operatorCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.860
+	NAME 'netbootServer'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.369
+	NAME 'fSMORoleOwner'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.276
+	NAME 'driverVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1388
+	NAME 'mS-SQL-Version'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.939
+	NAME 'mSMQNameStyle'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.471
+	NAME 'schemaVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.2.436
+	NAME 'directReports'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.2.255
+	NAME 'addressSyntax'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.235
+	NAME 'printFormName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.15
+	NAME 'msiScriptPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1312
+	NAME 'aCSServerList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 1.2.840.113556.1.2.615
+#	NAME 'personalTitle'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+#
+# Moved to microsoftattributetype.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.30.  Personal Title
+#
+#  The Personal Title attribute type specifies a personal title for a
+#  person. Examples of personal titles are "Ms", "Dr", "Prof" and "Rev".
+#
+#    personalTitle ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            caseIgnoreStringSyntax
+#            (SIZE (1 .. ub-personal-title))
+#    ::= {pilotAttributeType 40}
+#
+attributetype ( 0.9.2342.19200300.100.1.40 NAME 'personalTitle'
+	DESC 'RFC1274: personal title'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+
+attributetype ( 1.2.840.113556.1.4.1305
+	NAME 'moveTreeState'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.945
+	NAME 'mSMQSiteGates'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.1238
+	NAME 'mSMQDsService'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.76
+	NAME 'objectVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1414
+	NAME 'dNSTombstoned'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.941
+	NAME 'mSMQLongLived'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.534
+	NAME 'fRSLevelLimit'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.845
+	NAME 'msiScriptName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.4.44
+#	NAME 'homeDirectory'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.698
+	NAME 'dhcpUniqueKey'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.227
+	NAME 'extensionName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 1.2.840.113556.1.2.256
+#	NAME 'streetAddress'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.113
+	NAME 'rpcNsBindings'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.237
+	NAME 'printBinNames'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.109
+	NAME 'replicaSource'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.246
+	NAME 'printLanguage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1365
+	NAME 'mS-SQL-Contact'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.357
+	NAME 'nTMixedDomain'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.483
+	NAME 'fRSFileFilter'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.332
+	NAME 'birthLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.682
+	NAME 'friendlyNames'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.622
+	NAME 'ipsecDataType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.584
+	NAME 'meetingRating'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.681
+	NAME 'indexedScopes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.312
+	NAME 'rpcNsObjectID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.168
+	NAME 'modifiedCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.218
+	NAME 'oMObjectClass'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.772
+	NAME 'aCSPolicyName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.502
+	NAME 'timeVolChange'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.337
+	NAME 'currMachineId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.120
+	NAME 'schemaFlagsEx'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1356
+	NAME 'validAccesses'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.158
+	NAME 'domainReplica'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1309
+	NAME 'mSMQInterval2'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1308
+	NAME 'mSMQInterval1'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.916
+	NAME 'canonicalName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.94
+	NAME 'ntPwdHistory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.133
+	NAME 'trustPartner'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.160
+	NAME 'lmPwdHistory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.1380
+	NAME 'mS-SQL-Status'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.469
+	NAME 'USNIntersite'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.858
+	NAME 'netbootTools'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.99
+	NAME 'priorSetTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1367
+	NAME 'mS-SQL-Memory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.950
+	NAME 'mSMQServices'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.2.613
+#	NAME 'employeeType'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.27
+	NAME 'currentValue'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.822
+	NAME 'siteLinkList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.107
+	NAME 'remoteSource'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.325
+	NAME 'setupCommand'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.212
+	NAME 'dSHeuristics'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1336
+	NAME 'replInterval'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.234
+	NAME 'printEndTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.1
+        NAME 'instanceType'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.722
+	NAME 'otherIpPhone'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.965
+	NAME 'mSMQSiteName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.579
+	NAME 'meetingOwner'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.242
+	NAME 'printCollate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.480
+	NAME 'defaultGroup'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.79
+	NAME 'minPwdLength'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.864
+	NAME 'netbootSCPBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.650
+	NAME 'mhsORAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 1.2.840.113556.1.4.651
+#	NAME 'otherMailbox'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+#
+# Moved to microsoftattributetype.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.18.  Other Mailbox
+#
+#  The Other Mailbox attribute type specifies values for electronic
+#  mailbox types other than X.400 and rfc822.
+#
+#    otherMailbox ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            SEQUENCE {
+#                    mailboxType PrintableString, -- e.g. Telemail
+#                    mailbox IA5String  -- e.g. X378:Joe
+#            }
+#    ::= {pilotAttributeType 22}
+#
+attributetype ( 0.9.2342.19200300.100.1.22 NAME 'otherMailbox'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.39 )
+
+
+attributetype ( 1.2.840.113556.1.4.367
+	NAME 'rpcNsCodeset'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.14
+	NAME 'hasMasterNCs'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.952
+	NAME 'mSMQMigrated'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.74
+	NAME 'dSASignature'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.115
+	NAME 'invocationId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.254
+	NAME 'cOMTypelibId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.26
+	NAME 'creationTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.581
+	NAME 'meetingScope'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.336
+	NAME 'volTableGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.513
+	NAME 'siteObjectBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.756
+	NAME 'aCSTimeOfDay'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.757
+	NAME 'aCSDirection'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.77
+	NAME 'maxTicketAge'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.481
+	NAME 'schemaUpdate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.80
+	NAME 'minTicketAge'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.628
+	NAME 'ipsecNegotiationPolicyReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.327
+	NAME 'helpFileName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.148
+	NAME 'schemaIDGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.810
+	NAME 'createDialog'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.964
+	NAME 'mSMQNt4Flags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.327
+	NAME 'packageFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.464
+	NAME 'wWWHomePage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.507
+	NAME 'volumeCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.273
+	NAME 'printStatus'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.890
+	NAME 'uPNSuffixes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.471
+	NAME 'trustParent'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1301
+	NAME 'tokenGroups'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.375
+	NAME 'systemFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.667
+	NAME 'syncWithSID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1306
+	NAME 'dNSProperty'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.710
+	NAME 'superScopes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.1347
+	NAME 'sPNMappings'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.272
+	NAME 'printNotify'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.282
+	NAME 'printMemory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.154
+	NAME 'serverState'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.942
+	NAME 'mSMQVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.373
+	NAME 'rIDUsedPool'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1355
+	NAME 'queryFilter'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.300
+	NAME 'printerName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.97
+	NAME 'preferredOU'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.649
+	NAME 'primaryInternationalISDNNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.333
+	NAME 'oMTIndxGuid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1337
+	NAME 'mSMQUserSid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.487
+	NAME 'fRSRootPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.918
+	NAME 'mSMQJournal'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.499
+	NAME 'contextMenu'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.764
+	NAME 'aCSPriority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.937
+	NAME 'mSMQSignKey'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.359
+	NAME 'netbootGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.925
+	NAME 'mSMQOwnerID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.24
+	NAME 'mustContain'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38' )
+
+attributetype ( 1.2.840.113556.1.4.379
+	NAME 'dnsAllowXFR'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1379
+	NAME 'mS-SQL-Vines'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.948
+	NAME 'mSMQDigests'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.662
+	NAME 'lockoutTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.53
+	NAME 'lastSetTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.25
+	NAME 'countryCode'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1377
+	NAME 'mS-SQL-TCPIP'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.934
+	NAME 'mSMQForeign'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.571
+	NAME 'meetingType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.714
+	NAME 'dhcpOptions'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.704
+	NAME 'dhcpServers'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.283
+	NAME 'assetNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.350
+	NAME 'addressType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.940
+	NAME 'mSMQCSPName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.671
+	NAME 'msiFileList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.619
+	NAME 'dNSHostName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.705
+	NAME 'dhcpSubnets'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.1328
+	NAME 'pKIKeyUsage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.30
+	NAME 'attributeID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.506
+	NAME 'objectCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.503
+	NAME 'timeRefresh'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.139
+	NAME 'profilePath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.818
+	NAME 'productCode'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.647
+	NAME 'otherMobile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.12
+	NAME 'badPwdCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1368
+	NAME 'mS-SQL-Build'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.2.13
+#	NAME 'displayName'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.87
+	NAME 'nETBIOSName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1395
+	NAME 'mS-SQL-Alias'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.75
+	NAME 'maxRenewAge'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.806
+	NAME 'treatAsLeaf'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.960
+	NAME 'mSMQNt4Stub'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.324
+	NAME 'packageType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1212
+	NAME 'isEphemeral'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.2.36
+	NAME 'dMDLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.715
+	NAME 'dhcpClasses'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.39
+	NAME 'forceLogoff'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.2
+        NAME 'whenCreated'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.566
+	NAME 'meetingName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.786
+	NAME 'mailAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.590
+	NAME 'meetingBlob'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.71
+	NAME 'machineRole'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.334
+	NAME 'searchFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.3
+        NAME 'whenChanged'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.702
+	NAME 'dhcpObjName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.897
+	NAME 'aCSMaxAggregatePeakRatePerUser'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.326
+	NAME 'packageName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.170
+	NAME 'systemOnly'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.935
+	NAME 'mSMQOSType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.680
+	NAME 'queryPoint'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.271
+	NAME 'printOwner'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.19
+        NAME 'uSNCreated'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.494
+	NAME 'siteServer'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.114
+	NAME 'rpcNsGroup'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.609
+	NAME 'sIDHistory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.882
+	NAME 'fRSVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.64
+	NAME 'logonHours'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.854
+	NAME 'netbootAnswerOnlyValidClients'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.96
+	NAME 'pwdLastSet'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.243
+	NAME 'printColor'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1391
+	NAME 'mS-SQL-Type'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.40
+	NAME 'fromServer'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.157
+	NAME 'serverRole'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.100
+	NAME 'priorValue'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.169
+	NAME 'logonCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.90
+	NAME 'unicodePwd'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.21
+	NAME 'subClassOf'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1396
+	NAME 'mS-SQL-Size'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.101
+	NAME 'privateKey'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.512
+	NAME 'siteObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.62
+	NAME 'scriptPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.223
+	NAME 'serverName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.953
+	NAME 'mSMQSiteID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.340
+	NAME 'rightsGuid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.374
+	NAME 'rIDNextRID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.583
+	NAME 'meetingURL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.400
+	NAME 'addressEntryDisplayTableMSDOS'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.76
+	NAME 'maxStorage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.35
+	NAME 'rangeUpper'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.34
+	NAME 'rangeLower'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.118
+	NAME 'otherPager'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.639
+	NAME 'isMemberOfPartialAttributeSet'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1224
+	NAME 'parentGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.1.2.1.1 NAME 'department'
+        DESC 'Department Name'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.25
+	NAME 'mayContain'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38' )
+
+attributetype ( 1.2.840.113556.1.4.150
+	NAME 'adminCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.51
+	NAME 'lastLogoff'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1409
+	NAME 'masteredBy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.35
+	NAME 'employeeID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.719
+	NAME 'dhcpMaxKey'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.229
+	NAME 'driverName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1363
+	NAME 'mS-SQL-Name'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.322
+	NAME 'categoryId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.889
+	NAME 'additionalTrustedServiceNames'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1354
+	NAME 'scopeFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.672
+	NAME 'categories'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.855
+	NAME 'netbootNewMachineNamingPolicy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.19
+	NAME 'cOMClassID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.120 
+        NAME 'uSNChanged' 
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' 
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.2
+        NAME 'objectGUID'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.707
+	NAME 'dhcpRanges'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.1358
+	NAME 'schemaInfo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.646
+	NAME 'otherFacsimileTelephoneNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.520
+	NAME 'machinePasswordChangeInterval'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.674
+	NAME 'rootTrust'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.136
+	NAME 'trustType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.750
+	NAME 'groupType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.896
+	NAME 'uSNSource'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.919
+	NAME 'mSMQQuota'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.927
+	NAME 'mSMQSites'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.910
+	NAME 'fromEntry'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1376
+	NAME 'mS-SQL-SPX'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.892
+	NAME 'gPOptions'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.814
+	NAME 'msiScript'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.285
+	NAME 'printRate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.683
+	NAME 'cRLPartitionedRevocationList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.652
+	NAME 'assistant'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.490
+	NAME 'fRSDSPoll'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.663
+	NAME 'partialAttributeDeletionList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.52
+	NAME 'lastLogon'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.22
+	NAME 'governsID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.341
+	NAME 'appliesTo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.268
+	NAME 'eFSPolicy'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.155
+	NAME 'uASCompat'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.538
+	NAME 'prefixMap'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.661
+	NAME 'isDefunct'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.708
+	NAME 'dhcpSites'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.888
+	NAME 'iPSECNegotiationPolicyAction'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.382
+	NAME 'dnsRecord'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.21
+	NAME 'cOMProgID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.45
+	NAME 'homeDrive'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.580
+	NAME 'meetingIP'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1321
+	NAME 'aCSNonReservedMinPolicedSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.717
+	NAME 'dhcpState'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.922
+	NAME 'mSMQLabel'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.74
+	NAME 'maxPwdAge'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.78
+	NAME 'minPwdAge'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.689
+	NAME 'cRLObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.146
+	NAME 'objectSid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.565
+	NAME 'meetingID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.620
+	NAME 'ipsecName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.48
+	NAME 'isDeleted'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.760
+	NAME 'aCSAggregateTokenRatePerUser'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.623
+	NAME 'ipsecData'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.668
+	NAME 'domainCAs'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.687
+	NAME 'cAConnect'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.238
+	NAME 'printMaxResolutionSupported'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.700
+	NAME 'dhcpFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.402
+	NAME 'helpData16'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.653
+        NAME 'managedBy'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.9
+	NAME 'helpData32'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.944
+	NAME 'mSMQSite2'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.943
+	NAME 'mSMQSite1'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.677
+	NAME 'replTopologyStayOfExecution'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.912
+	NAME 'allowedChildClassesEffective'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.2.231
+	NAME 'oMSyntax'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.231
+	NAME 'priority'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.48
+	NAME 'keywords'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.946
+	NAME 'mSMQCost'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.821
+	NAME 'siteList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.145
+	NAME 'revision'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.91
+	NAME 'repsFrom'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.645
+	NAME 'userCert'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.951
+	NAME 'mSMQQMID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.228
+	NAME 'portName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.859
+	NAME 'netbootLocallyInstalledOSes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.261
+	NAME 'division'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.902
+	NAME 'aCSMaxSizeOfRSVPAccountFile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.699
+	NAME 'dhcpType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.301
+	NAME 'wbemPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.362
+	NAME 'siteGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.26
+	NAME 'rDNAttID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.900
+	NAME 'aCSRSVPAccountFilesLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1226
+	NAME 'mSMQDependentClientServices'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.222
+	NAME 'location'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.874
+	NAME 'fRSFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.219
+	NAME 'iconPath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.688
+	NAME 'cAWEBURL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.716
+	NAME 'mscopeId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.660
+	NAME 'treeName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.211
+	NAME 'schedule'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.557
+	NAME 'parentCA'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.249
+	NAME 'cOMCLSID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.675
+	NAME 'catalogs'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.102
+	NAME 'memberOf'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.690
+	NAME 'cAUsages'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.706
+	NAME 'dhcpMask'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+attributetype ( 1.2.840.113556.1.4.511
+	NAME 'flatName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.686
+	NAME 'domainID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.58
+	NAME 'localeID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.16
+	NAME 'codePage'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.768
+	NAME 'aCSEnableRSVPMessageLogging'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.240
+	NAME 'printOrientationsSupported'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.883
+	NAME 'msRRASVendorAttributeEntry'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1246
+	NAME 'interSiteTopologyGenerator'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.307
+	NAME 'options'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.28
+	NAME 'dnsRoot'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.887
+	NAME 'iPSECNegotiationPolicyType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1392
+	NAME 'mS-SQL-InformationDirectory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.365
+	NAME 'operatingSystemServicePack'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.88
+	NAME 'nextRid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.865
+	NAME 'pekList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.7
+        NAME 'subRefs'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.505
+	NAME 'oMTGuid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.205
+	NAME 'pKTGuid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.1.2.1.2 NAME 'company'
+        DESC 'Company Name'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.82
+	NAME 'moniker'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.156
+	NAME 'comment'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.721
+	NAME 'ipPhone'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1361
+	NAME 'mS-DS-ConsistencyChildCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.679
+	NAME 'creator'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.137
+	NAME 'uNCName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.55
+	NAME 'dBCSPwd'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1239
+	NAME 'mSMQDependentClientService'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.684
+	NAME 'certificateAuthorityObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.621
+	NAME 'ipsecID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.914
+	NAME 'allowedAttributesEffective'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+#attributetype ( 1.2.840.113556.1.2.598
+#	NAME 'dmdName'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.759
+	NAME 'aCSMaxPeakBandwidthPerFlow'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.557
+	NAME 'Enabled'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.326
+	NAME 'perRecipDialogDisplayTable'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1248
+	NAME 'interSiteTopologyFailover'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.895
+	NAME 'transportAddressAttribute'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.852
+	NAME 'netbootCurrentClientCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.372
+	NAME 'rIDPreviousAllocationPool'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.2.83
+	NAME 'repsTo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.224
+	NAME 'defaultSecurityDescriptor'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.519
+	NAME 'lastBackupRestorationTime'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.873
+	NAME 'fRSControlOutboundBacklog'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.255
+	NAME 'vendor'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.891
+        NAME 'gPLink'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.214
+	NAME 'originalDisplayTableMSDOS'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.50
+	NAME 'linkID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1130
+	NAME 'msNPSavedCallingStationID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26' )
+
+attributetype ( 1.2.840.113556.1.2.49
+	NAME 'mAPIID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.510
+	NAME 'serviceBindingInformation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.16
+	NAME 'nCName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1303
+	NAME 'tokenGroupsNoGCAcceptable'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.1418
+	NAME 'tokenGroupsGlobalAndUniversal'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.1190
+	NAME 'msRASSavedFramedIPAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.766
+	NAME 'aCSAllocableRSVPBandwidth'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.61
+	NAME 'lockOutObservationWindow'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.857
+	NAME 'netbootIntelliMirrorOSes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1320
+	NAME 'aCSNonReservedMaxSDUSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.265
+	NAME 'notes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.673
+	NAME 'retiredReplDSASignatures'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1313
+	NAME 'aCSMaxTokenBucketPerFlow'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.324
+	NAME 'addressEntryDisplayTable'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1317
+	NAME 'aCSMinimumDelayVariation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.872
+	NAME 'fRSControlInboundBacklog'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.38
+	NAME 'flags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1399
+	NAME 'mS-SQL-LastDiagnosticDate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1348
+	NAME 'gPCMachineExtensionNames'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1411
+	NAME 'ms-DS-MachineAccountQuota'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.325
+	NAME 'perMsgDialogDisplayTable'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.57
+	NAME 'defaultLocalPolicyObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1189
+	NAME 'msRASSavedCallbackNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.685
+	NAME 'parentCACertificateChain'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.893
+	NAME 'gPCFunctionalityVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.879
+	NAME 'fRSServiceCommandStatus'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1319
+	NAME 'aCSNonReservedTokenSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.775
+	NAME 'aCSMaxSizeOfRSVPLogFile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.135
+	NAME 'cost'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.81
+	NAME 'modifiedCountAtLastProm'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.773
+	NAME 'aCSRSVPLogFilesLocation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.2.81
+#	NAME 'info'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.125
+	NAME 'supplementalCredentials'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.819
+	NAME 'bridgeheadTransportList'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.967
+	NAME 'mSMQSignCertificatesMig'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+#attributetype ( 1.2.840.113556.1.4.1
+#	NAME 'name'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE
+#	 )
+
+attributetype ( 1.2.840.113556.1.4.1153
+	NAME 'msRADIUSFramedIPAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1408
+	NAME 'mS-DS-ReplicatesNCReason'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.899
+	NAME 'aCSEnableRSVPAccounting'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.881
+	NAME 'fRSTimeLastConfigChange'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.281
+	NAME 'printStaplingSupported'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1247
+	NAME 'interSiteTopologyRenew'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.364
+	NAME 'operatingSystemVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.91
+	NAME 'otherLoginWorkstations'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.849
+	NAME 'netbootAllowNewClients'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1372
+	NAME 'mS-SQL-UnicodeSortOrder'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.749
+	NAME 'url'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.206
+	NAME 'pKT'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.199
+	NAME 'serviceInstanceVersion'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.169
+	NAME 'showInAdvancedViewOnly'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.758
+	NAME 'aCSMaxTokenRatePerFlow'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.868
+	NAME 'isCriticalSystemObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.576
+	NAME 'meetingMaxParticipants'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1208
+	NAME 'aNR'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.153
+	NAME 'rid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.523
+	NAME 'proxyGenerationEnabled'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.871
+	NAME 'fRSControlDataCreation'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.692
+	NAME 'previousCACertificates'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.24
+	NAME 'contentIndexingAllowed'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.633
+	NAME 'policyReplicationFlags'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.870
+	NAME 'frsComputerReferenceBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1318
+	NAME 'aCSNonReservedPeakRate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.901
+	NAME 'aCSMaxNoOfAccountFiles'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.514
+	NAME 'physicalLocationObject'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.928
+	NAME 'mSMQOutRoutingServers'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.820
+	NAME 'bridgeheadServerListBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1145
+	NAME 'msRADIUSCallbackNumber'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.361
+	NAME 'netbootMachineFilePath'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.963
+	NAME 'mSMQQueueJournalQuota'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.853
+	NAME 'netbootAnswerRequests'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.415
+	NAME 'operatingSystemHotfix'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.149
+	NAME 'attributeSecurityGUID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.711
+	NAME 'superScopeDescription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1359
+	NAME 'otherWellKnownObjects'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.780
+	NAME 'aCSNonReservedTxLimit'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.11
+	NAME 'authenticationOptions'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.867
+	NAME 'altSecurityIdentities'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1349
+	NAME 'gPCUserExtensionNames'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.358
+	NAME 'netbootInitialization'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1364
+	NAME 'mS-SQL-RegisteredOwner'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.761
+	NAME 'aCSMaxDurationPerFlow'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1330
+	NAME 'pKICriticalExtensions'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.748
+	NAME 'attributeDisplayNames'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1404
+	NAME 'mS-SQL-AllowImmediateUpdatingSubscription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1191
+	NAME 'msRASSavedFramedRoute'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26' )
+
+attributetype ( 1.2.840.113556.1.4.752
+	NAME 'userSharedFolderOther'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 1.2.840.113556.1.2.131
+#	NAME 'co'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.909
+	NAME 'extendedAttributeInfo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1241
+	NAME 'netbootMirrorDataFile'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1315
+	NAME 'aCSMinimumPolicedSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1353
+	NAME 'localizationDisplayId'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.582
+	NAME 'meetingAdvertiseScope'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1343
+	NAME 'dSUIAdminNotification'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.1381
+	NAME 'mS-SQL-LastUpdatedDate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1357
+        NAME 'dSCorePropagationData'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.24' )
+
+attributetype ( 1.2.840.113556.1.4.320
+	NAME 'implementedCategories'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+attributetype ( 1.2.840.113556.1.4.783
+	NAME 'defaultObjectCategory'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.422
+	NAME 'domainPolicyReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.929
+	NAME 'mSMQInRoutingServers'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.1311
+	NAME 'printDuplexSupported'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.693
+	NAME 'pendingCACertificates'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.281
+        NAME 'nTSecurityDescriptor'
+        SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+        SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.198
+	NAME 'systemAuxiliaryClass'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.898
+	NAME 'aCSNonReservedTxSize'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1382
+	NAME 'mS-SQL-InformationURL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.3
+	NAME 'replPropertyMetaData'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.1384
+	NAME 'mS-SQL-PublicationURL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.275
+	NAME 'printKeepPrintedJobs'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.267
+	NAME 'uSNDSALastObjRemoved'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.381
+	NAME 'dnsNotifySecondaries'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.1360
+	NAME 'mS-DS-ConsistencyGuid'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.869
+	NAME 'frsComputerReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1369
+	NAME 'mS-SQL-ServiceAccount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1124
+	NAME 'msNPCallingStationID'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26' )
+
+attributetype ( 1.2.840.113556.1.4.947
+	NAME 'mSMQSignCertificates'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.624
+	NAME 'ipsecOwnersReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.14
+	NAME 'builtinModifiedCount'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.634
+	NAME 'privilegeDisplayName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.380
+	NAME 'dnsSecureSecondaries'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+attributetype ( 1.2.840.113556.1.4.817
+	NAME 'localizedDescription'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.195
+	NAME 'systemPossSuperiors'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+	 )
+
+attributetype ( 1.2.840.113556.1.2.353
+	NAME 'displayNamePrintable'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.771
+	NAME 'servicePrincipalName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.866
+	NAME 'pekKeyChangeInterval'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.445
+	NAME 'originalDisplayTable'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1398
+	NAME 'mS-SQL-LastBackupDate'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.517
+	NAME 'ipsecPolicyReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.823
+	NAME 'certificateTemplates'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.2.15
+	NAME 'hasPartialReplicaNCs'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.457
+	NAME 'localPolicyReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.2.380
+	NAME 'extendedCharsAllowed'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.629
+	NAME 'ipsecFilterReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+attributetype ( 1.2.840.113556.1.4.626
+	NAME 'ipsecISAKMPReference'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.876
+	NAME 'fRSMemberReferenceBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.314
+	NAME 'rpcNsTransferSyntax'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1227
+	NAME 'mSMQRoutingServices'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1375
+	NAME 'mS-SQL-MultiProtocol'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.825
+	NAME 'enrollmentProviders'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.287
+	NAME 'printNetworkAddress'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1171
+	NAME 'msRADIUSServiceType'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.631
+	NAME 'printPagesPerMinute'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.299
+	NAME 'printMediaSupported'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+attributetype ( 1.2.840.113556.1.4.824
+	NAME 'signatureAlgorithms'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.877
+	NAME 'fRSPartnerAuthLevel'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.636
+	NAME 'privilegeAttributes'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.640
+	NAME 'partialAttributeSet'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE
+	 )
+
+attributetype ( 1.2.840.113556.1.4.850
+	NAME 'netbootLimitClients'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1383
+	NAME 'mS-SQL-ConnectionURL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1406
+	NAME 'mS-SQL-AllowSnapshotFilesFTPDownloading'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.7'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1331
+	NAME 'pKIExpirationPeriod'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.531
+	NAME 'nonSecurityMemberBL'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+	 )
+
+attributetype ( 1.2.840.113556.1.4.540
+	NAME 'initialAuthOutgoing'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 1.2.840.113556.1.4.1158
+	NAME 'msRADIUSFramedRoute'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.26' )
+
+attributetype ( 1.2.840.113556.1.4.200
+	NAME 'controlAccessRights'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+

--- a/scripts/docker/auth/openldap/schema/microsoftattributetypestd.schema
+++ b/scripts/docker/auth/openldap/schema/microsoftattributetypestd.schema
@@ -1,0 +1,382 @@
+#####################################################
+
+#attributetype ( 2.5.4.0
+#	NAME 'objectClass'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.38'
+#	 )
+
+#attributetype ( 2.5.4.2
+#	NAME 'knowledgeInformation'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+#attributetype ( 2.5.4.3
+#	NAME 'cn'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.4
+#	NAME 'sn'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.5
+#	NAME 'serialNumber'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+#attributetype ( 2.5.4.6
+#	NAME 'c'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.7
+#	NAME 'l'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.8
+#	NAME 'st'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.9
+#	NAME 'street'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.10
+#	NAME 'o'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 2.5.4.11
+#	NAME 'ou'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 2.5.4.12
+#	NAME 'title'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.13
+#	NAME 'description'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 2.5.4.14
+#	NAME 'searchGuide'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.15
+#	NAME 'businessCategory'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 2.5.4.16
+#	NAME 'postalAddress'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 2.5.4.17
+#	NAME 'postalCode'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.18
+#	NAME 'postOfficeBox'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+
+#attributetype ( 2.5.4.19
+#	NAME 'physicalDeliveryOfficeName'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.20
+#	NAME 'telephoneNumber'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.21
+#	NAME 'telexNumber'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.22
+#	NAME 'teletexTerminalIdentifier'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.23
+#	NAME 'facsimileTelephoneNumber'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.24
+#	NAME 'x121Address'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.36' )
+
+#attributetype ( 2.5.4.25
+#	NAME 'internationalISDNNumber'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.36' )
+
+#attributetype ( 2.5.4.26
+#	NAME 'registeredAddress'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.27
+#	NAME 'destinationIndicator'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.44' )
+
+#attributetype ( 2.5.4.28
+#	NAME 'preferredDeliveryMethod'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )
+
+#attributetype ( 2.5.4.29
+#	NAME 'presentationAddress'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.43'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.30
+#	NAME 'supportedApplicationContext'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.31
+#	NAME 'member'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+#attributetype ( 2.5.4.32
+#	NAME 'owner'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.33
+#	NAME 'roleOccupant'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+#attributetype ( 2.5.4.34
+#	NAME 'seeAlso'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
+
+#attributetype ( 2.5.4.35
+#	NAME 'userPassword'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.36
+#	NAME 'userCertificate'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.37
+#	NAME 'cACertificate'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.38
+#	NAME 'authorityRevocationList'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.39
+#	NAME 'certificateRevocationList'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.40
+#	NAME 'crossCertificatePair'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.4.42
+#	NAME 'givenName'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.43
+#	NAME 'initials'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.44
+#	NAME 'generationQualifier'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 2.5.4.49
+#	NAME 'distinguishedName'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+#	SINGLE-VALUE
+#	 )
+
+#attributetype ( 2.5.4.53
+#	NAME 'deltaRevocationList'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#attributetype ( 2.5.18.1
+#	NAME 'createTimeStamp'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+#	SINGLE-VALUE
+#	 )
+
+#attributetype ( 2.5.18.2
+#	NAME 'modifyTimeStamp'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.24'
+#	SINGLE-VALUE
+#	 )
+
+#attributetype ( 2.5.18.10
+#	NAME 'subSchemaSubEntry'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+#	 )
+
+#attributetype ( 2.5.21.2
+#	NAME 'dITContentRules'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	 )
+
+#attributetype ( 2.5.21.5
+#	NAME 'attributeTypes'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	 )
+
+#attributetype ( 2.5.21.6
+#	NAME 'objectClasses'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	 )
+
+# Clash with OpenLdap: 2.16.840.1.113730.3.1.34 NAME 'ref'
+attributetype ( 2.16.840.1.113730.3.1.34.0
+	NAME 'middleName'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+attributetype ( 2.16.840.1.113730.3.1.35
+	NAME 'thumbnailPhoto'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+attributetype ( 2.16.840.1.113730.3.1.36
+	NAME 'thumbnailLogo'
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40'
+	SINGLE-VALUE )
+
+#attributetype ( 2.16.840.1.113730.3.140
+#	NAME 'userSMIMECertificate'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.40' )
+
+#####################################################
+
+#attributetype ( 0.9.2342.19200300.100.1.2
+#	NAME 'textEncodedORAddress'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 0.9.2342.19200300.100.1.3
+#	NAME 'mail'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+#attributetype ( 0.9.2342.19200300.100.1.10
+#	NAME 'manager'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.12'
+#	SINGLE-VALUE )
+#
+# Moved to microsoftattributetypestd.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.10.  Manager
+#
+#  The Manager attribute type specifies the manager of an object
+#  represented by an entry.
+#
+#    manager ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            distinguishedNameSyntax
+#    ::= {pilotAttributeType 10}
+#
+attributetype ( 0.9.2342.19200300.100.1.10 NAME 'manager'
+	DESC 'RFC1274: DN of manager'
+	EQUALITY distinguishedNameMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
+
+# Moved to microsoftattributetypestd.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.16.  Home Telephone Number
+#
+#  The Home Telephone Number attribute type specifies a home telephone
+#  number associated with a person.  Attribute values should follow the
+#  agreed format for international telephone numbers: i.e., "+44 71 123
+#  4567".
+#
+#    homeTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            telephoneNumberSyntax
+#    ::= {pilotAttributeType 20}
+#
+#attributetype ( 0.9.2342.19200300.100.1.20
+#	NAME ( 'homePhone' 'homeTelephoneNumber' )
+#	DESC 'RFC1274: home telephone number'
+#	EQUALITY telephoneNumberMatch
+#	SUBSTR telephoneNumberSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50 )
+#
+#
+# MS 0.9.2342.19200300.100.1.20 can contain any kind of string
+attributetype ( 0.9.2342.19200300.100.1.20
+	NAME ( 'homePhone' 'homeTelephoneNumber' )
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+#attributetype ( 0.9.2342.19200300.100.1.25
+#	NAME 'dc'
+#	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+#	SINGLE-VALUE )
+
+# Moved to microsoftattributetypestd.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.31.  Mobile Telephone Number
+#
+#  The Mobile Telephone Number attribute type specifies a mobile
+#  telephone number associated with a person.  Attribute values should
+#  follow the agreed format for international telephone numbers: i.e.,
+#  "+44 71 123 4567".
+#
+#    mobileTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            telephoneNumberSyntax
+#    ::= {pilotAttributeType 41}
+#
+#attributetype ( 0.9.2342.19200300.100.1.41
+#	NAME ( 'mobile' 'mobileTelephoneNumber' )
+#	DESC 'RFC1274: mobile telephone number'
+#	EQUALITY telephoneNumberMatch
+#	SUBSTR telephoneNumberSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50 )
+#
+#
+# MS 0.9.2342.19200300.100.1.41 can contain any kind of string
+attributetype ( 0.9.2342.19200300.100.1.41
+	NAME ( 'mobile' 'mobileTelephoneNumber' )
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+
+# Moved to microsoftattributetypestd.schema to satisfy
+# organizationalPerson objectclass
+#
+# 9.3.32.  Pager Telephone Number
+#
+#  The Pager Telephone Number attribute type specifies a pager telephone
+#  number for an object. Attribute values should follow the agreed
+#  format for international telephone numbers: i.e., "+44 71 123 4567".
+#
+#    pagerTelephoneNumber ATTRIBUTE
+#        WITH ATTRIBUTE-SYNTAX
+#            telephoneNumberSyntax
+#    ::= {pilotAttributeType 42}
+#
+#attributetype ( 0.9.2342.19200300.100.1.42
+#	NAME ( 'pager' 'pagerTelephoneNumber' )
+#	DESC 'RFC1274: pager telephone number'
+#	EQUALITY telephoneNumberMatch
+#	SUBSTR telephoneNumberSubstringsMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.50 )
+#
+#
+# MS 0.9.2342.19200300.100.1.42 can contain any kind of string
+attributetype ( 0.9.2342.19200300.100.1.42
+	NAME ( 'pager' 'pagerTelephoneNumber' )
+	SYNTAX '1.3.6.1.4.1.1466.115.121.1.15'
+	SINGLE-VALUE )
+
+

--- a/scripts/docker/auth/openldap/schema/microsoftobjectclass.schema
+++ b/scripts/docker/auth/openldap/schema/microsoftobjectclass.schema
@@ -1,0 +1,298 @@
+objectclass ( 1.2.840.113556.1.3.23
+ NAME 'container'
+ SUP 'top'
+ STRUCTURAL
+ MUST ( cn )
+ MAY ( schemaVersion $ defaultClassStore )
+ )
+
+objectclass ( 1.2.840.113556.1.5.67
+        NAME 'domainDNS'
+        SUP domain
+        STRUCTURAL
+        MAY (managedBy $ msDS-AllowedDNSSuffixes $ msDS-Behavior-Version $ msDS-EnabledFeature $ msDS-USNLastSyncSuccess $ msExchPolicyList ) )
+
+objectclass ( 1.2.840.113556.1.5.8
+        NAME 'group'
+        SUP top
+        STRUCTURAL 
+        MUST ( groupType )
+        MAY ( adminCount $ controlAccessRights $ dLMemberRule $ desktopProfile $ groupAttributes $ groupMembershipSAM $ hideDLMembership $
+              location $ mail $ managedBy $ member $ msDS-AzApplicationData $ msDS-AzBizRule $ msDS-AzBizRuleLanguage $ msDS-AzGenericData $
+              msDS-AzLDAPQuery $ msDS-AzLastImportedBizRulePath $ msDS-AzObjectGuid $ msDS-HABSeniorityIndex $ msDS-NonMembers $ msDS-PhoneticDisplayName $
+              msExchArbitrationMailbox $ msExchCoManagedByLink $ msExchGroupDepartRestriction $ msExchGroupJoinRestriction $ msExchMasterAccountHistory $
+              msExchOriginatingForest $ msExchServerAdminDelegationBL $ msOrg-GroupSubtypeName $ msOrg-IsOrganizational $ msOrg-Leaders $
+              msOrg-OtherDisplayNames $ msSFU30Name $ msSFU30NisDomain $ msSFU30PosixMember $ nTGroupMembers $ nonSecurityMember $ oOFReplyToOriginator $
+              operatorCount $ owner $ primaryGroupToken $ reportToOriginator $ reportToOwner $ thumbnailPhoto
+            ) )
+
+objectclass ( 1.2.840.113556.1.5.15
+        NAME 'contact'
+        SUP organizationalPerson
+        STRUCTURAL 
+        MUST ( cn )
+        MAY ( msDS-SourceObjectDN $ msExchMasterAccountHistory $ msExchOriginatingForest $ notes
+            ) )
+
+#---
+
+# mstop is the new root objectclass for all MS entries.
+# The origin OpenLdap top objectclass cannot be modified as
+# it is hardcoded in the OpenLdap source code.
+# OID must be changed together as it causes OID clash.
+#
+# The data etries must be converted to use 'mstop' instead of 'top'
+objectclass ( 666.666.666.666.666.666.1
+        NAME 'mstop'
+        SUP top
+        AUXILIARY
+        MUST (objectClass $ instanceType $ objectCategory )
+        MAY (cn $ description $ distinguishedName $ whenCreated $
+                whenChanged $ subRefs $ displayName $ uSNCreated $ isDeleted $
+                dSASignature $ objectVersion $ repsTo $ repsFrom $ memberOf $
+                uSNChanged $ uSNLastObjRem $ showInAdvancedViewOnly $
+                adminDisplayName $ proxyAddresses $ adminDescription $
+                extensionName $ uSNDSALastObjRemoved $ displayNamePrintable $
+                directReports $ wWWHomePage $ USNIntersite $ name $ objectGUID $
+                replPropertyMetaData $ replUpToDateVector $ flags $ revision $
+                wbemPath $ fSMORoleOwner $ systemFlags $ siteObjectBL $ 
+                serverReferenceBL $ nonSecurityMemberBL $ queryPolicyBL $
+                wellKnownObjects $ isPrivilegeHolder $ partialAttributeSet $
+                managedObjects $ partialAttributeDeletionList $ url $
+                lastKnownParent $ bridgeheadServerListBL $ netbootSCPBL $
+                isCriticalSystemObject $ frsComputerReferenceBL $
+                fRSMemberReferenceBL $ uSNSource $ fromEntry $
+                allowedChildClasses $ allowedChildClassesEffective $
+                allowedAttributes $ allowedAttributesEffective $
+                possibleInferiors $ canonicalName $ proxiedObjectName $
+                sDRightsEffective $ dSCorePropagationData $
+                otherWellKnownObjects $ mS-DS-ConsistencyGuid $
+                mS-DS-ConsistencyChildCount $ nTSecurityDescriptor $ masteredBy ) )
+
+objectclass ( 1.2.840.113556.1.5.9
+        NAME 'user'
+        SUP organizationalPerson
+        STRUCTURAL
+        MAY (userCertificate $ networkAddress $ userAccountControl $
+                badPwdCount $ codePage $ homeDirectory $ homeDrive $
+                badPasswordTime $ lastLogoff $ lastLogon $ dBCSPwd $
+                localeID $ scriptPath $ logonHours $ logonWorkstation $
+                maxStorage $ userWorkstations $ unicodePwd $
+                otherLoginWorkstations $ ntPwdHistory $ pwdLastSet $
+                preferredOU $ primaryGroupID $ userParameters $
+                profilePath $ operatorCount $ adminCount $ accountExpires $
+                lmPwdHistory $ groupMembershipSAM $ logonCount $
+                controlAccessRights $ defaultClassStore $ groupsToIgnore $
+                groupPriority $ desktopProfile $ dynamicLDAPServer $
+                userPrincipalName $ lockoutTime $ userSharedFolder $
+                userSharedFolderOther $ servicePrincipalName $
+                aCSPolicyName $ terminalServer $ mSMQSignCertificates $
+                mSMQDigests $ mSMQDigestsMig $ mSMQSignCertificatesMig $
+                msNPAllowDialin $ msNPCallingStationID $
+                msNPSavedCallingStationID $ msRADIUSCallbackNumber $
+                msRADIUSFramedIPAddress $ msRADIUSFramedRoute $
+                msRADIUSServiceType $ msRASSavedCallbackNumber $
+                msRASSavedFramedIPAddress $ msRASSavedFramedRoute $
+                mS-DS-CreatorSID 
+             ) )
+
+#---
+
+# Custom user objectclass containing all Microsoft attributes 
+# used by Active Directory user
+objectclass ( 666.666.666.666.666.666.2
+        NAME 'customActiveDirectoryUser'
+        SUP user
+        STRUCTURAL
+        MUST (objectSid $ sAMAccountName $ sAMAccountType 
+             ) 
+        MAY (homeMTA $ homeMDB $ mDBUseDefaults $ msExchSafeSendersHash $ msExchMobileMailboxFlags $ msExchObjectsDeletedThisPeriod $
+             legacyExchangeDN $ lastLogonTimestamp $ internetEncoding $ protocolSettings $ garbageCollPeriod $ altRecipientBL $
+             textEncodedORAddress $ msExchUMEnabledFlags2 $ msExchUserCulture $ msExchMDBRulesQuota $ msExchUMDtmfMap $ authOrigBL $
+             msExchHomeServerName $ msExchProvisioningFlags $ msExchTransportRecipientSettingsFlags $ msExchModerationFlags $
+             msExchMailboxSecurityDescriptor $ msExchDumpsterWarningQuota $ msExchDumpsterQuota $ msExchArchiveWarnQuota $ msExchArchiveQuota $
+             msExchUserAccountControl $ msExchMailboxAuditLogAgeLimit $ msExchMailboxAuditEnable $ msExchBypassAudit $ msExchAddressBookFlags $
+             msExchALObjectVersion $ msExchMailboxMoveBatchName $ msExchMailboxMoveFlags $ msExchMailboxMoveStatus $
+             msExchMailboxMoveTargetMDBLink $ msExchBlockedSendersHash $ msExchPoliciesExcluded $ msExchPoliciesIncluded $
+             msExchTextMessagingState $ msExchDelegateListBL $ altRecipient $ msExchHideFromAddressLists $
+             msExchOmaAdminWirelessEnable $ showInAddressBook $ msExchShadowProxyAddresses $ msExchCoManagedObjectsBL $
+             extensionAttribute1 $ mDBOverQuotaLimit $ msDS-SupportedEncryptionTypes $ mDBOverHardQuotaLimit $
+             mDBStorageQuota $ msExchSafeRecipientsHash $ msExchBypassModerationBL $ msExchShadowMailNickname $
+             publicDelegates $ publicDelegatesBL $ msExchLastExchangeChangedTime $ msExchShadowGivenName $
+             msExchMailboxGuid $ msExchRecipientDisplayType $ msExchShadowManagerLink $ msExchRequireAuthToSendTo $
+             msExchRBACPolicyLink $ msExchVersion $ msExchRecipientTypeDetails $ msExchWhenMailboxCreated $
+             extensionAttribute10 $ msExchMasterAccountSid $ securityProtocol $ dLMemDefault $ delivContLength $
+             extensionAttribute2 $ extensionAttribute3 $ extensionAttribute4 $ extensionAttribute5 $ extensionAttribute6 $
+             extensionAttribute7 $ extensionAttribute8 $ extensionAttribute9 $ mAPIRecipient $ msExchADCGlobalNames $
+             msExchAssistantName $ replicatedObjectVersion $ replicationSignature $ submissionContLength $ telephoneAssistant $
+             msExchShadowDisplayName $ msExchShadowSn $ deliverAndRedirect $ msExchDelegateListLink $ deletedItemFlags $
+             msExchShadowCompany $ msExchShadowDepartment $ msExchShadowTitle $ msExchShadowPhysicalDeliveryOfficeName $
+             msTSExpireDate $ msTSLicenseVersion $ msTSManagingLS $ msExchShadowCountryCode $ autoReplyMessage $ msExchELCMailboxFlags $
+             msExchShadowInitials $ msExchShadowMobile $ msExchModeratedObjectsBL $ msExchUserBL $ msExchMailboxTemplateLink $
+             msExchIMACL $ msExchIMAddress $ msExchIMMetaPhysicalURL $ msExchIMPhysicalURL $ msExchIMVirtualServer $
+             msExchMobileMailboxPolicyLink $ msExchMailboxMoveSourceMDBLink $ apple-mcxsettings $ msExchResourceDisplay $
+             msExchResourceMetaData $ msExchResourceSearchProperties $ msExchRemoteRecipientType $ targetAddress $ 
+             msExchMailboxMoveRemoteHostName $ msExchMobileAllowedDeviceIDs $ msExchSharingPartnerIdentities
+            ) )
+
+# Support for ExchangeActiveSyncDevices entries (sub-entry of customActiveDirectoryUser/user)
+objectclass ( 666.666.666.666.666.666.3
+        NAME 'exchangeActiveSyncDevices'
+        SUP top
+        STRUCTURAL
+        MUST (msExchVersion
+             ) 
+        MAY ( cn $ msExchObjectsDeletedThisPeriod 
+            ) )
+
+objectclass ( 666.666.666.666.666.666.4
+        NAME 'customActiveDirectoryUserTemplate'
+        SUP user
+        STRUCTURAL
+        MUST (objectSid $ sAMAccountName $ sAMAccountType
+             ) 
+        MAY ( msDS-SupportedEncryptionTypes $ msExchUserAccountControl $ legacyExchangeDN $ msExchALObjectVersion $ msExchPoliciesIncluded $
+              textEncodedORAddress
+            ) )
+
+# Fake object class simulating attributes used by 'group' entries coming from 
+# inetOrgPerson
+objectclass ( 666.666.666.666.666.666.5
+    NAME 'inetOrgGroup'
+    SUP group
+    STRUCTURAL
+    MAY (
+        audio $ businessCategory $ carLicense $ departmentNumber $
+        displayName $ employeeNumber $ employeeType $ givenName $
+        homePhone $ homePostalAddress $ initials $ jpegPhoto $
+        labeledURI $ mail $ manager $ mobile $ o $ pager $
+        photo $ roomNumber $ secretary $ uid $ userCertificate $
+        x500uniqueIdentifier $ preferredLanguage $
+        userSMIMECertificate $ userPKCS12 $ proxyAddresses $
+        department $ company $ mailNickname )
+    )
+
+# Fake object class simulating attributes used by 'group' entries coming from 
+# organizationalPerson
+objectclass ( 666.666.666.666.666.666.6
+    NAME 'organizationalGroup'
+    SUP inetOrgGroup
+    STRUCTURAL
+    MAY ( title $ x121Address $ registeredAddress $ destinationIndicator $
+        preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+        telephoneNumber $ internationaliSDNNumber $
+        facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+        postalAddress $ physicalDeliveryOfficeName $ ou $ st $ l $ c $ co $ info $ mailNickname $
+        o $ internationalISDNNumber $ givenName $ initials $ generationQualifier $
+        otherTelephone $ otherPager $ department $ company $ streetAddress $ otherHomePhone $
+        personalTitle $ homePostalAddress $ countryCode $ employeeID $ comment $ division $
+        otherFacsimileTelephoneNumber $ otherMobile $ primaryTelexNumber $
+        primaryInternationalISDNNumber $ mhsORAddress $ otherMailbox $ assistant $
+        ipPhone $ otherIpPhone $ mail $ manager $ homePhone $ mobile $ pager $ middleName $
+        thumbnailPhoto $ thumbnailLogo
+        ) )
+
+# Custom group objectclass containing all Microsoft attributes 
+# used by Active Directory group
+objectclass ( 666.666.666.666.666.666.7
+        NAME 'customActiveDirectoryGroup'
+        SUP organizationalGroup
+        STRUCTURAL
+        MUST (objectSid $ sAMAccountName $ sAMAccountType 
+             ) 
+        MAY (homeMTA $ homeMDB $ mDBUseDefaults $ msExchSafeSendersHash $ msExchMobileMailboxFlags $ msExchObjectsDeletedThisPeriod $
+             legacyExchangeDN $ lastLogonTimestamp $ internetEncoding $ protocolSettings $ garbageCollPeriod $ altRecipientBL $
+             textEncodedORAddress $ msExchUMEnabledFlags2 $ msExchUserCulture $ msExchMDBRulesQuota $ msExchUMDtmfMap $ authOrigBL $
+             msExchHomeServerName $ msExchProvisioningFlags $ msExchTransportRecipientSettingsFlags $ msExchModerationFlags $
+             msExchMailboxSecurityDescriptor $ msExchDumpsterWarningQuota $ msExchDumpsterQuota $ msExchArchiveWarnQuota $ msExchArchiveQuota $
+             msExchUserAccountControl $ msExchMailboxAuditLogAgeLimit $ msExchMailboxAuditEnable $ msExchBypassAudit $ msExchAddressBookFlags $
+             msExchALObjectVersion $ msExchMailboxMoveBatchName $ msExchMailboxMoveFlags $ msExchMailboxMoveStatus $
+             msExchMailboxMoveTargetMDBLink $ msExchBlockedSendersHash $ msExchPoliciesExcluded $ msExchPoliciesIncluded $
+             msExchTextMessagingState $ msExchDelegateListBL $ altRecipient $ msExchHideFromAddressLists $
+             msExchOmaAdminWirelessEnable $ showInAddressBook $ msExchShadowProxyAddresses $ msExchCoManagedObjectsBL $
+             extensionAttribute1 $ mDBOverQuotaLimit $ msDS-SupportedEncryptionTypes $ mDBOverHardQuotaLimit $
+             mDBStorageQuota $ msExchSafeRecipientsHash $ msExchBypassModerationBL $ msExchShadowMailNickname $
+             publicDelegates $ publicDelegatesBL $ msExchLastExchangeChangedTime $ msExchShadowGivenName $
+             msExchMailboxGuid $ msExchRecipientDisplayType $ msExchShadowManagerLink $ msExchRequireAuthToSendTo $
+             msExchRBACPolicyLink $ msExchVersion $ msExchRecipientTypeDetails $ msExchWhenMailboxCreated $
+             extensionAttribute10 $ msExchMasterAccountSid $ securityProtocol $ dLMemDefault $ delivContLength $
+             extensionAttribute2 $ extensionAttribute3 $ extensionAttribute4 $ extensionAttribute5 $ extensionAttribute6 $
+             extensionAttribute7 $ extensionAttribute8 $ extensionAttribute9 $ mAPIRecipient $ msExchADCGlobalNames $
+             msExchAssistantName $ replicatedObjectVersion $ replicationSignature $ submissionContLength $ telephoneAssistant $
+             msExchShadowDisplayName $ msExchShadowSn $ deliverAndRedirect $ msExchDelegateListLink $ deletedItemFlags $
+             msExchShadowCompany $ msExchShadowDepartment $ msExchShadowTitle $ msExchShadowPhysicalDeliveryOfficeName $
+             msTSExpireDate $ msTSLicenseVersion $ msTSManagingLS $ msExchShadowCountryCode $ autoReplyMessage $ msExchELCMailboxFlags $
+             msExchShadowInitials $ msExchShadowMobile $ msExchModeratedObjectsBL $ msExchUserBL $ dLMemSubmitPerms $ authOrig $
+             dLMemSubmitPermsBL $ msExchBypassModerationLink $ msExchEnableModeration $ msExchModeratedByLink $ msExchSenderHintTranslations $
+             msExchExpansionServerName $ unmergedAtts
+            ) )
+
+# Custom group objectclass containing all Microsoft attributes 
+# used by Active Directory contact
+objectclass ( 666.666.666.666.666.666.8
+        NAME 'customActiveDirectoryContact'
+        SUP contact
+        STRUCTURAL
+        MAY ( DUP-labeledURI-e20b3d32-5a2b-4f6c-84c0-65c94ba52437 $ DUP-secretary-00efea41-cee1-4f20-b9c3-a2a93ec60616 $
+              altRecipient $ altRecipientBL $ assistant $ authOrig $ authOrigBL $ autoReplyMessage $ company $ dLMemDefault $
+              dLMemRejectPerms $ dLMemRejectPermsBL $ dLMemSubmitPerms $ dLMemSubmitPermsBL $ delivContLength $ delivExtContTypes $
+              deliverAndRedirect $ deliveryMechanism $ department $ dnQualifier $ enabledProtocols $ expirationTime $ extensionData $
+              folderPathname $ formData $ forwardingAddress $ garbageCollPeriod $ homeMTA $ importedFrom $ info $ internetEncoding $
+              language $ languageCode $ legacyExchangeDN $ mAPIRecipient $ mail $ mailNickname $ msDS-HABSeniorityIndex $ 
+              msDS-PhoneticDisplayName $ msExchAddressBookFlags $ msExchAggregationSubscriptionCredential $ msExchArbitrationMailbox $
+              msExchAssistantName $ msExchAuditAdmin $ msExchAuditDelegate $ msExchAuditDelegateAdmin $ msExchAuditOwner $ 
+              msExchBlockedSendersHash $ msExchBypassAudit $ msExchBypassModerationBL $ msExchBypassModerationFromDLMembersBL $
+              msExchBypassModerationFromDLMembersLink $ msExchBypassModerationLink $ msExchCalculatedTargetAddress $ 
+              msExchCalendarRepairDisabled $ msExchCapabilityIdentifiers $ msExchCoManagedObjectsBL $ msExchCustomProxyAddresses $
+              msExchDirsyncID $ msExchDirsyncSourceObjectClass $ msExchEdgeSyncRetryCount $ msExchEnableModeration $
+              msExchEwsApplicationAccessPolicy $ msExchEwsEnabled $ msExchEwsExceptions $ msExchEwsWellKnownApplicationPolicies $
+              msExchExpansionServerName $ msExchExternalSyncState $ msExchFBURL $ msExchForeignGroupSID $ msExchGenericForwardingAddress $
+              msExchHABShowInDepartments $ msExchImmutableId $ msExchIntendedMailboxPlanLink $ msExchInterruptUserOnAuditFailure $
+              msExchLabeledURI $ msExchLicenseToken $ msExchLitigationHoldDate $ msExchLitigationHoldOwner $ msExchMailboxAuditEnable $
+              msExchMailboxAuditLastAdminAccess $ msExchMailboxAuditLastDelegateAccess $ msExchMailboxAuditLastExternalAccess $
+              msExchMailboxAuditLogAgeLimit $ msExchMailboxFolderSet $ msExchMailboxFolderSet2 $ msExchMailboxMoveBatchName $
+              msExchMailboxMoveFlags $ msExchMailboxMoveRemoteHostName $ msExchMailboxMoveSourceArchiveMDBLink $
+              msExchMailboxMoveSourceMDBLink $ msExchMailboxMoveStatus $ msExchMailboxMoveTargetArchiveMDBLink $
+              msExchMailboxMoveTargetMDBLink $ msExchMailboxPlanType $ msExchMailboxSecurityDescriptor $ msExchMasterAccountSid $
+              msExchMessageHygieneFlags $ msExchMessageHygieneSCLDeleteThreshold $ msExchMessageHygieneSCLJunkThreshold $
+              msExchMessageHygieneSCLQuarantineThreshold $ msExchMessageHygieneSCLRejectThreshold $ msExchModeratedByLink $
+              msExchModeratedObjectsBL $ msExchModerationFlags $ msExchOWAPolicy $ msExchObjectID $ msExchParentPlanLink $
+              msExchPartnerGroupID $ msExchPoliciesExcluded $ msExchPoliciesIncluded $ msExchPolicyEnabled $ msExchPolicyOptionList $
+              msExchPreviousAccountSid $ msExchProvisioningFlags $ msExchProxyCustomProxy $ msExchRBACPolicyLink $ 
+              msExchRMSComputerAccountsLink $ msExchRecipLimit $ msExchRecipientDisplayType $ msExchRecipientTypeDetails $
+              msExchRemoteRecipientType $ msExchRequireAuthToSendTo $ msExchResourceCapacity $ msExchResourceDisplay $
+              msExchResourceMetaData $ msExchResourceSearchProperties $ msExchRetentionComment $ msExchRetentionURL $
+              msExchSafeRecipientsHash $ msExchSafeSendersHash $ msExchSendAsAddresses $ msExchSenderHintTranslations $
+              msExchSharingAnonymousIdentities $ msExchSharingPartnerIdentities $ msExchSharingPolicyLink $ msExchSignupAddresses $
+              msExchSupervisionDLLink $ msExchSupervisionOneOffLink $ msExchSupervisionUserLink $ msExchSyncAccountsPolicyDN $
+              msExchTextMessagingState $ msExchThrottlingPolicyDN $ msExchTransportRecipientSettingsFlags $ msExchUCVoiceMailSettings $
+              msExchUMAddresses $ msExchUMCallingLineIDs $ msExchUMDtmfMap $ msExchUMListInDirectorySearch $ msExchUMRecipientDialPlanLink $
+              msExchUMSpokenName $ msExchUsageLocation $ msExchUserAccountControl $ msExchWhenMailboxCreated $ msExchWindowsLiveID $
+              pOPCharacterSet $ pOPContentFormat $ protocolSettings $ publicDelegates $ publicDelegatesBL $ replicationSensitivity $
+              securityProtocol $ showInAddressBook $ submissionContLength $ targetAddress $ telephoneNumber $ textEncodedORAddress $
+              unauthOrig $ unauthOrigBL $ userCert $ userCertificate $ userSMIMECertificate $ versionNumber $
+              msExchVersion $ msExchALObjectVersion $ msExchHideFromAddressLists $ msExchADCGlobalNames $ replicatedObjectVersion $
+              replicationSignature
+            ) )
+
+# Custom computer objectclass representing computer account 
+objectclass ( 1.2.840.113556.1.3.30
+        NAME 'computer'
+        SUP customActiveDirectoryUser
+        STRUCTURAL
+        MAY ( catalogs $ cn $ dNSHostName $ defaultLocalPolicyObject $ localPolicyFlags $ location $ logRolloverInterval $ 
+              machineRole $ managedBy $ monitoredConfigurations $ monitoredServices $ monitoringAvailabilityStyle $ 
+              monitoringAvailabilityWindow $ monitoringCachedViaMail $ monitoringCachedViaRPC $ monitoringMailUpdateInterval $ 
+              monitoringMailUpdateUnits $ monitoringRPCUpdateInterval $ monitoringRPCUpdateUnits $ msDS-AdditionalDnsHostName $ 
+              msDS-AdditionalSamAccountName $ msDS-AuthenticatedAtDC $ msDS-ExecuteScriptPassword $ msDS-HostServiceAccount $ 
+              msDS-IsUserCachableAtRodc $ msDS-KrbTgtLink $ msDS-NeverRevealGroup $ msDS-PromotionSettings $ msDS-RevealOnDemandGroup $ 
+              msDS-RevealedList $ msDS-RevealedUsers $ msDS-SiteName $ msDS-isGC $ msDS-isRODC $ msExchExchangeServerLink $ 
+              msExchPolicyList $ msExchPolicyOptionList $ msSFU30Aliases $ msSFU30Name $ msSFU30NisDomain $ msTPM-OwnerInformation $ 
+              msTSEndpointData $ msTSEndpointPlugin $ msTSEndpointType $ msTSPrimaryDesktopBL $ msTSProperty01 $ msTSProperty02 $ 
+              msTSSecondaryDesktopBL $ netbootGUID $ netbootInitialization $ netbootMachineFilePath $ netbootMirrorDataFile $ 
+              netbootSIFFile $ networkAddress $ nisMapName $ operatingSystem $ operatingSystemHotfix $ operatingSystemServicePack $ 
+              operatingSystemVersion $ physicalLocationObject $ policyReplicationFlags $ promoExpiration $ rIDSetReferences $ 
+              securityProtocol $ siteGUID $ trackingLogPathName $ type $ volumeCount
+            ) )
+
+

--- a/scripts/docker/auth/openldap/schema/misc.schema
+++ b/scripts/docker/auth/openldap/schema/misc.schema
@@ -1,0 +1,75 @@
+# misc.schema -- assorted schema definitions
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+# Assorted definitions from several sources, including
+# ''works in progress''.  Contents of this file are
+# subject to change (including deletion) without notice.
+#
+# Not recommended for production use!
+# Use with extreme caution!
+
+#-----------------------------------------------------------
+# draft-lachman-laser-ldap-mail-routing-02.txt !!!EXPIRED!!!
+#	(a work in progress)
+#
+attributetype ( 2.16.840.1.113730.3.1.13
+	NAME 'mailLocalAddress'
+	DESC 'RFC822 email address of this recipient'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+
+attributetype ( 2.16.840.1.113730.3.1.18
+	NAME 'mailHost'
+	DESC 'FQDN of the SMTP/MTA of this recipient'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256}
+	SINGLE-VALUE )
+
+attributetype ( 2.16.840.1.113730.3.1.47
+	NAME 'mailRoutingAddress'
+	DESC 'RFC822 routing address of this recipient'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256}
+	SINGLE-VALUE )
+
+# I-D leaves this OID TBD.
+# iPlanet uses 2.16.840.1.113.730.3.2.147 but that is an
+# improperly delegated OID.  A typo is likely.
+objectclass ( 2.16.840.1.113730.3.2.147
+	NAME 'inetLocalMailRecipient'
+	DESC 'Internet local mail recipient'
+	SUP top AUXILIARY
+	MAY	( mailLocalAddress $ mailHost $ mailRoutingAddress ) )
+
+#-----------------------------------------------------------
+# draft-srivastava-ldap-mail-00.txt !!!EXPIRED!!!
+#	(a work in progress)
+#
+attributetype ( 1.3.6.1.4.1.42.2.27.2.1.15
+	NAME 'rfc822MailMember'
+	DESC 'rfc822 mail address of group member(s)'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+#-----------------------------------------------------------
+# !!!no I-D!!!
+#	(a work in progress)
+#
+objectclass ( 1.3.6.1.4.1.42.2.27.1.2.5
+	NAME 'nisMailAlias'
+	DESC 'NIS mail alias'
+	SUP top STRUCTURAL
+	MUST cn
+	MAY rfc822MailMember )

--- a/scripts/docker/auth/openldap/schema/nis.schema
+++ b/scripts/docker/auth/openldap/schema/nis.schema
@@ -1,0 +1,237 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+
+# Definitions from RFC2307 (Experimental)
+#	An Approach for Using LDAP as a Network Information Service
+
+# Depends upon core.schema and cosine.schema
+
+# Note: The definitions in RFC2307 are given in syntaxes closely related
+# to those in RFC2252, however, some liberties are taken that are not
+# supported by RFC2252.  This file has been written following RFC2252
+# strictly.
+
+# OID Base is iso(1) org(3) dod(6) internet(1) directory(1) nisSchema(1).
+# i.e. nisSchema in RFC2307 is 1.3.6.1.1.1
+#
+# Syntaxes are under 1.3.6.1.1.1.0 (two new syntaxes are defined)
+#	validaters for these syntaxes are incomplete, they only
+#	implement printable string validation (which is good as the
+#	common use of these syntaxes violates the specification).
+# Attribute types are under 1.3.6.1.1.1.1
+# Object classes are under 1.3.6.1.1.1.2
+
+# Attribute Type Definitions
+
+# builtin
+#attributetype ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+#	DESC 'An integer uniquely identifying a user in an administrative domain'
+#	EQUALITY integerMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+# builtin
+#attributetype ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+#	DESC 'An integer uniquely identifying a group in an administrative domain'
+#	EQUALITY integerMatch
+#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.2 NAME 'gecos'
+	DESC 'The GECOS field; the common name'
+	EQUALITY caseIgnoreIA5Match
+	SUBSTR caseIgnoreIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
+	DESC 'The absolute path to the home directory'
+	EQUALITY caseExactIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
+	DESC 'The path to the login shell'
+	EQUALITY caseExactIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.6 NAME 'shadowMin'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.7 NAME 'shadowMax'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.12 NAME 'memberUid'
+	EQUALITY caseExactIA5Match
+	SUBSTR caseExactIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+	EQUALITY caseExactIA5Match
+	SUBSTR caseExactIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
+	DESC 'Netgroup triple'
+	SYNTAX 1.3.6.1.1.1.0.0 )
+
+attributetype ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
+	SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber'
+	EQUALITY integerMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+	DESC 'IP address'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+
+attributetype ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+	DESC 'IP network'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+	DESC 'IP netmask'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+	DESC 'MAC address'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+
+attributetype ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
+	DESC 'rpc.bootparamd parameter'
+	SYNTAX 1.3.6.1.1.1.0.1 )
+
+attributetype ( 1.3.6.1.1.1.1.24 NAME 'bootFile'
+	DESC 'Boot image name'
+	EQUALITY caseExactIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+	SUP name )
+
+attributetype ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
+	EQUALITY caseExactIA5Match
+	SUBSTR caseExactIA5SubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{1024} SINGLE-VALUE )
+
+# Object Class Definitions
+
+objectclass ( 1.3.6.1.1.1.2.0 NAME 'posixAccount'
+	DESC 'Abstraction of an account with POSIX attributes'
+	SUP top AUXILIARY
+	MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
+	MAY ( userPassword $ loginShell $ gecos $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount'
+	DESC 'Additional attributes for shadow passwords'
+	SUP top AUXILIARY
+	MUST uid
+	MAY ( userPassword $ shadowLastChange $ shadowMin $
+	      shadowMax $ shadowWarning $ shadowInactive $
+	      shadowExpire $ shadowFlag $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.2 NAME 'posixGroup'
+	DESC 'Abstraction of a group of accounts'
+	SUP top STRUCTURAL
+	MUST ( cn $ gidNumber )
+	MAY ( userPassword $ memberUid $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.3 NAME 'ipService'
+	DESC 'Abstraction an Internet Protocol service'
+	SUP top STRUCTURAL
+	MUST ( cn $ ipServicePort $ ipServiceProtocol )
+	MAY ( description ) )
+
+objectclass ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol'
+	DESC 'Abstraction of an IP protocol'
+	SUP top STRUCTURAL
+	MUST ( cn $ ipProtocolNumber $ description )
+	MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.5 NAME 'oncRpc'
+	DESC 'Abstraction of an ONC/RPC binding'
+	SUP top STRUCTURAL
+	MUST ( cn $ oncRpcNumber $ description )
+	MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.6 NAME 'ipHost'
+	DESC 'Abstraction of a host, an IP device'
+	SUP top AUXILIARY
+	MUST ( cn $ ipHostNumber )
+	MAY ( l $ description $ manager ) )
+
+objectclass ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork'
+	DESC 'Abstraction of an IP network'
+	SUP top STRUCTURAL
+	MUST ( cn $ ipNetworkNumber )
+	MAY ( ipNetmaskNumber $ l $ description $ manager ) )
+
+objectclass ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup'
+	DESC 'Abstraction of a netgroup'
+	SUP top STRUCTURAL
+	MUST cn
+	MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
+
+objectclass ( 1.3.6.1.1.1.2.9 NAME 'nisMap'
+	DESC 'A generic abstraction of a NIS map'
+	SUP top STRUCTURAL
+	MUST nisMapName
+	MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.10 NAME 'nisObject'
+	DESC 'An entry in a NIS map'
+	SUP top STRUCTURAL
+	MUST ( cn $ nisMapEntry $ nisMapName )
+	MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device'
+	DESC 'A device with a MAC address'
+	SUP top AUXILIARY
+	MAY macAddress )
+
+objectclass ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice'
+	DESC 'A device with boot parameters'
+	SUP top AUXILIARY
+	MAY ( bootFile $ bootParameter ) )

--- a/scripts/docker/auth/openldap/schema/openldap.schema
+++ b/scripts/docker/auth/openldap/schema/openldap.schema
@@ -1,0 +1,54 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+
+#
+# OpenLDAP Project's directory schema items
+#
+# depends upon:
+#	core.schema
+#	cosine.schema
+#	inetorgperson.schema
+#
+# These are provided for informational purposes only.
+
+objectIdentifier OpenLDAProot 1.3.6.1.4.1.4203
+
+objectIdentifier OpenLDAP OpenLDAProot:1
+objectIdentifier OpenLDAPattributeType OpenLDAP:3
+objectIdentifier OpenLDAPobjectClass OpenLDAP:4
+
+objectClass ( OpenLDAPobjectClass:3
+	NAME 'OpenLDAPorg'
+	DESC 'OpenLDAP Organizational Object'
+	SUP organization
+	MAY ( buildingName $ displayName $ labeledURI ) )
+
+objectClass ( OpenLDAPobjectClass:4
+	NAME 'OpenLDAPou'
+	DESC 'OpenLDAP Organizational Unit Object'
+	SUP organizationalUnit
+	MAY ( buildingName $ displayName $ labeledURI $ o ) )
+
+objectClass ( OpenLDAPobjectClass:5
+	NAME 'OpenLDAPperson'
+	DESC 'OpenLDAP Person'
+	SUP ( pilotPerson $ inetOrgPerson )
+	MUST ( uid $ cn )
+	MAY ( givenName $ labeledURI $ o ) )
+
+objectClass ( OpenLDAPobjectClass:6
+	NAME 'OpenLDAPdisplayableObject'
+	DESC 'OpenLDAP Displayable Object'
+	AUXILIARY
+	MAY displayName )

--- a/scripts/docker/auth/openldap/schema/pmi.schema
+++ b/scripts/docker/auth/openldap/schema/pmi.schema
@@ -1,0 +1,464 @@
+# OpenLDAP X.509 PMI schema
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 1998-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (1997-2006).
+## All Rights Reserved.
+##
+## This document and translations of it may be copied and furnished to
+## others, and derivative works that comment on or otherwise explain it
+## or assist in its implementation may be prepared, copied, published
+## and distributed, in whole or in part, without restriction of any
+## kind, provided that the above copyright notice and this paragraph are
+## included on all such copies and derivative works.  However, this
+## document itself may not be modified in any way, such as by removing
+## the copyright notice or references to the Internet Society or other
+## Internet organizations, except as needed for the purpose of
+## developing Internet standards in which case the procedures for
+## copyrights defined in the Internet Standards process must be         
+## followed, or as required to translate it into languages other than
+## English.
+##                                                                      
+## The limited permissions granted above are perpetual and will not be  
+## revoked by the Internet Society or its successors or assigns.        
+## 
+## This document and the information contained herein is provided on an 
+## "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+## TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+## BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+## HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+## MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+#
+#
+# Includes LDAPv3 schema items from:
+# ITU X.509 (08/2005)
+#
+## X.509 (08/2005) pp. 120-121
+## 
+## -- object identifier assignments --
+## -- object classes --
+## id-oc-pmiUser                            OBJECT IDENTIFIER ::= {id-oc 24}
+## id-oc-pmiAA                              OBJECT IDENTIFIER ::= {id-oc 25}
+## id-oc-pmiSOA                             OBJECT IDENTIFIER ::= {id-oc 26}
+## id-oc-attCertCRLDistributionPts          OBJECT IDENTIFIER ::= {id-oc 27}
+## id-oc-privilegePolicy                    OBJECT IDENTIFIER ::= {id-oc 32}
+## id-oc-pmiDelegationPath                  OBJECT IDENTIFIER ::= {id-oc 33}
+## id-oc-protectedPrivilegePolicy           OBJECT IDENTIFIER ::= {id-oc 34}
+## -- directory attributes --
+## id-at-attributeCertificate               OBJECT IDENTIFIER ::= {id-at 58}
+## id-at-attributeCertificateRevocationList OBJECT IDENTIFIER ::= {id-at 59}
+## id-at-aACertificate                      OBJECT IDENTIFIER ::= {id-at 61}
+## id-at-attributeDescriptorCertificate     OBJECT IDENTIFIER ::= {id-at 62}
+## id-at-attributeAuthorityRevocationList   OBJECT IDENTIFIER ::= {id-at 63}
+## id-at-privPolicy                         OBJECT IDENTIFIER ::= {id-at 71}
+## id-at-role                               OBJECT IDENTIFIER ::= {id-at 72}
+## id-at-delegationPath                     OBJECT IDENTIFIER ::= {id-at 73}
+## id-at-protPrivPolicy                     OBJECT IDENTIFIER ::= {id-at 74}
+## id-at-xMLPrivilegeInfo                   OBJECT IDENTIFIER ::= {id-at 75}
+## id-at-xMLPprotPrivPolicy                 OBJECT IDENTIFIER ::= {id-at 76}
+## -- attribute certificate extensions --
+## id-ce-authorityAttributeIdentifier       OBJECT IDENTIFIER ::= {id-ce 38}
+## id-ce-roleSpecCertIdentifier             OBJECT IDENTIFIER ::= {id-ce 39}
+## id-ce-basicAttConstraints                OBJECT IDENTIFIER ::= {id-ce 41}
+## id-ce-delegatedNameConstraints           OBJECT IDENTIFIER ::= {id-ce 42}
+## id-ce-timeSpecification                  OBJECT IDENTIFIER ::= {id-ce 43}
+## id-ce-attributeDescriptor                OBJECT IDENTIFIER ::= {id-ce 48}
+## id-ce-userNotice                         OBJECT IDENTIFIER ::= {id-ce 49}
+## id-ce-sOAIdentifier                      OBJECT IDENTIFIER ::= {id-ce 50}
+## id-ce-acceptableCertPolicies             OBJECT IDENTIFIER ::= {id-ce 52}
+## id-ce-targetInformation                  OBJECT IDENTIFIER ::= {id-ce 55}
+## id-ce-noRevAvail                         OBJECT IDENTIFIER ::= {id-ce 56}
+## id-ce-acceptablePrivilegePolicies        OBJECT IDENTIFIER ::= {id-ce 57}
+## id-ce-indirectIssuer                     OBJECT IDENTIFIER ::= {id-ce 61}
+## id-ce-noAssertion                        OBJECT IDENTIFIER ::= {id-ce 62}
+## id-ce-issuedOnBehalfOf                   OBJECT IDENTIFIER ::= {id-ce 64}
+## -- PMI matching rules --
+## id-mr-attributeCertificateMatch          OBJECT IDENTIFIER ::= {id-mr 42}
+## id-mr-attributeCertificateExactMatch     OBJECT IDENTIFIER ::= {id-mr 45}
+## id-mr-holderIssuerMatch                  OBJECT IDENTIFIER ::= {id-mr 46}
+## id-mr-authAttIdMatch                     OBJECT IDENTIFIER ::= {id-mr 53}
+## id-mr-roleSpecCertIdMatch                OBJECT IDENTIFIER ::= {id-mr 54}
+## id-mr-basicAttConstraintsMatch           OBJECT IDENTIFIER ::= {id-mr 55}
+## id-mr-delegatedNameConstraintsMatch      OBJECT IDENTIFIER ::= {id-mr 56}
+## id-mr-timeSpecMatch                      OBJECT IDENTIFIER ::= {id-mr 57}
+## id-mr-attDescriptorMatch                 OBJECT IDENTIFIER ::= {id-mr 58}
+## id-mr-acceptableCertPoliciesMatch        OBJECT IDENTIFIER ::= {id-mr 59}
+## id-mr-delegationPathMatch                OBJECT IDENTIFIER ::= {id-mr 61}
+## id-mr-sOAIdentifierMatch                 OBJECT IDENTIFIER ::= {id-mr 66}
+## id-mr-indirectIssuerMatch                OBJECT IDENTIFIER ::= {id-mr 67}
+## 
+## 
+## X.509 (08/2005) pp. 71, 86-89
+##
+## 14.4.1 Role attribute
+## role  ATTRIBUTE ::= {
+##       WITH SYNTAX         RoleSyntax
+##       ID                  id-at-role }
+## RoleSyntax ::= SEQUENCE {
+## roleAuthority     [0]     GeneralNames  OPTIONAL,
+## roleName          [1]     GeneralName }
+## 
+## 14.5     XML privilege information attribute
+##    xmlPrivilegeInfo ATTRIBUTE ::= {
+##      WITH SYNTAX UTF8String -- contains XML-encoded privilege information
+##      ID                 id-at-xMLPrivilegeInfo }
+## 
+## 17.1 PMI directory object classes
+## 
+## 17.1.1   PMI user object class
+##    pmiUser OBJECT-CLASS ::= {
+##    -- a PMI user (i.e., a "holder")
+##      SUBCLASS OF          {top}
+##      KIND                 auxiliary
+##      MAY CONTAIN          {attributeCertificateAttribute}
+##      ID                   id-oc-pmiUser }
+## 
+## 17.1.2     PMI AA object class
+##     pmiAA OBJECT-CLASS ::= {
+##     -- a PMI AA
+##       SUBCLASS OF          {top}
+##       KIND                 auxiliary
+##       MAY CONTAIN          {aACertificate |
+##                            attributeCertificateRevocationList |
+##                            attributeAuthorityRevocationList}
+##       ID                   id-oc-pmiAA }
+## 
+## 17.1.3     PMI SOA object class
+##     pmiSOA OBJECT-CLASS ::= { -- a PMI Source of Authority
+##       SUBCLASS OF {top}
+##       KIND                 auxiliary
+##       MAY CONTAIN          {attributeCertificateRevocationList |
+##                            attributeAuthorityRevocationList |
+##                            attributeDescriptorCertificate}
+##       ID                   id-oc-pmiSOA }
+## 
+## 17.1.4     Attribute certificate CRL distribution point object class
+##     attCertCRLDistributionPt          OBJECT-CLASS ::= {
+##       SUBCLASS OF {top}
+##       KIND                 auxiliary
+##       MAY CONTAIN          { attributeCertificateRevocationList |
+##                            attributeAuthorityRevocationList }
+##       ID                   id-oc-attCertCRLDistributionPts }
+## 
+## 17.1.5     PMI delegation path
+##     pmiDelegationPath            OBJECT-CLASS ::= {
+##         SUBCLASS OF              {top}
+##         KIND                     auxiliary
+##         MAY CONTAIN              { delegationPath }
+##         ID                       id-oc-pmiDelegationPath }
+## 
+## 17.1.6     Privilege policy object class
+##     privilegePolicy        OBJECT-CLASS ::= {
+##         SUBCLASS OF              {top}
+##         KIND                     auxiliary
+##         MAY CONTAIN              {privPolicy }
+##         ID                       id-oc-privilegePolicy }
+## 
+## 17.1.7     Protected privilege policy object class
+##     protectedPrivilegePolicy               OBJECT-CLASS       ::= {
+##         SUBCLASS OF              {top}
+##         KIND                     auxiliary
+##         MAY CONTAIN            {protPrivPolicy }
+##         ID                     id-oc-protectedPrivilegePolicy }
+## 
+## 17.2       PMI Directory attributes
+## 
+## 17.2.1     Attribute certificate attribute
+##     attributeCertificateAttribute ATTRIBUTE ::= {
+##         WITH SYNTAX                            AttributeCertificate
+##         EQUALITY MATCHING RULE                 attributeCertificateExactMatch
+##         ID                                     id-at-attributeCertificate }
+## 
+## 17.2.2     AA certificate attribute
+##     aACertificate         ATTRIBUTE ::= {
+##         WITH SYNTAX                            AttributeCertificate
+##         EQUALITY MATCHING RULE                 attributeCertificateExactMatch
+##         ID                                     id-at-aACertificate }
+## 
+## 17.2.3     Attribute descriptor certificate attribute
+##     attributeDescriptorCertificate        ATTRIBUTE ::= {
+##         WITH SYNTAX                            AttributeCertificate
+##         EQUALITY MATCHING RULE                 attributeCertificateExactMatch
+##         ID                                     id-at-attributeDescriptorCertificate }
+## 
+## 17.2.4     Attribute certificate revocation list attribute
+##     attributeCertificateRevocationList         ATTRIBUTE ::= {
+##         WITH SYNTAX                            CertificateList
+##         EQUALITY MATCHING RULE                 certificateListExactMatch
+##         ID                                     id-at-attributeCertificateRevocationList}
+## 
+## 17.2.5     AA certificate revocation list attribute
+##     attributeAuthorityRevocationList           ATTRIBUTE ::= {
+##         WITH SYNTAX                            CertificateList
+##         EQUALITY MATCHING RULE                 certificateListExactMatch
+##         ID                                     id-at-attributeAuthorityRevocationList }
+## 
+## 17.2.6     Delegation path attribute
+##     delegationPath        ATTRIBUTE ::= {
+##         WITH SYNTAX                  AttCertPath
+##         ID                           id-at-delegationPath }
+##     AttCertPath      ::= SEQUENCE OF AttributeCertificate
+## 
+## 17.2.7     Privilege policy attribute
+##     privPolicy ATTRIBUTE ::= {
+##         WITH SYNTAX             PolicySyntax
+##         ID                      id-at-privPolicy }
+## 
+## 17.2.8     Protected privilege policy attribute
+##        protPrivPolicy       ATTRIBUTE        ::= {
+##         WITH SYNTAX                          AttributeCertificate
+##         EQUALITY MATCHING RULE               attributeCertificateExactMatch
+##         ID                                   id-at-protPrivPolicy }
+## 
+## 17.2.9     XML Protected privilege policy attribute
+##        xmlPrivPolicy        ATTRIBUTE ::= {
+##         WITH SYNTAX         UTF8String -- contains XML-encoded privilege policy information
+##         ID                  id-at-xMLPprotPrivPolicy }
+## 
+
+## -- object identifier assignments --
+## -- object classes --
+objectidentifier	id-oc-pmiUser 2.5.6.24
+objectidentifier	id-oc-pmiAA 2.5.6.25
+objectidentifier	id-oc-pmiSOA 2.5.6.26
+objectidentifier	id-oc-attCertCRLDistributionPts 2.5.6.27
+objectidentifier	id-oc-privilegePolicy 2.5.6.32
+objectidentifier	id-oc-pmiDelegationPath 2.5.6.33
+objectidentifier	id-oc-protectedPrivilegePolicy 2.5.6.34
+## -- directory attributes --
+objectidentifier	id-at-attributeCertificate 2.5.4.58
+objectidentifier	id-at-attributeCertificateRevocationList 2.5.4.59
+objectidentifier	id-at-aACertificate 2.5.4.61
+objectidentifier	id-at-attributeDescriptorCertificate 2.5.4.62
+objectidentifier	id-at-attributeAuthorityRevocationList 2.5.4.63
+objectidentifier	id-at-privPolicy 2.5.4.71
+objectidentifier	id-at-role 2.5.4.72
+objectidentifier	id-at-delegationPath 2.5.4.73
+objectidentifier	id-at-protPrivPolicy 2.5.4.74
+objectidentifier	id-at-xMLPrivilegeInfo 2.5.4.75
+objectidentifier	id-at-xMLPprotPrivPolicy 2.5.4.76
+## -- attribute certificate extensions --
+## id-ce-authorityAttributeIdentifier       OBJECT IDENTIFIER ::= {id-ce 38}
+## id-ce-roleSpecCertIdentifier             OBJECT IDENTIFIER ::= {id-ce 39}
+## id-ce-basicAttConstraints                OBJECT IDENTIFIER ::= {id-ce 41}
+## id-ce-delegatedNameConstraints           OBJECT IDENTIFIER ::= {id-ce 42}
+## id-ce-timeSpecification                  OBJECT IDENTIFIER ::= {id-ce 43}
+## id-ce-attributeDescriptor                OBJECT IDENTIFIER ::= {id-ce 48}
+## id-ce-userNotice                         OBJECT IDENTIFIER ::= {id-ce 49}
+## id-ce-sOAIdentifier                      OBJECT IDENTIFIER ::= {id-ce 50}
+## id-ce-acceptableCertPolicies             OBJECT IDENTIFIER ::= {id-ce 52}
+## id-ce-targetInformation                  OBJECT IDENTIFIER ::= {id-ce 55}
+## id-ce-noRevAvail                         OBJECT IDENTIFIER ::= {id-ce 56}
+## id-ce-acceptablePrivilegePolicies        OBJECT IDENTIFIER ::= {id-ce 57}
+## id-ce-indirectIssuer                     OBJECT IDENTIFIER ::= {id-ce 61}
+## id-ce-noAssertion                        OBJECT IDENTIFIER ::= {id-ce 62}
+## id-ce-issuedOnBehalfOf                   OBJECT IDENTIFIER ::= {id-ce 64}
+## -- PMI matching rules --
+objectidentifier	id-mr 2.5.13
+objectidentifier	id-mr-attributeCertificateMatch id-mr:42
+objectidentifier	id-mr-attributeCertificateExactMatch id-mr:45
+objectidentifier	id-mr-holderIssuerMatch id-mr:46
+objectidentifier	id-mr-authAttIdMatch id-mr:53
+objectidentifier	id-mr-roleSpecCertIdMatch id-mr:54
+objectidentifier	id-mr-basicAttConstraintsMatch id-mr:55
+objectidentifier	id-mr-delegatedNameConstraintsMatch id-mr:56
+objectidentifier	id-mr-timeSpecMatch id-mr:57
+objectidentifier	id-mr-attDescriptorMatch id-mr:58
+objectidentifier	id-mr-acceptableCertPoliciesMatch id-mr:59
+objectidentifier	id-mr-delegationPathMatch id-mr:61
+objectidentifier	id-mr-sOAIdentifierMatch id-mr:66
+objectidentifier	id-mr-indirectIssuerMatch id-mr:67
+## -- syntaxes --
+## NOTE: 1.3.6.1.4.1.4203.666.11.10 is the oid arc assigned by OpenLDAP
+## to this work in progress
+objectidentifier	AttributeCertificate 1.3.6.1.4.1.4203.666.11.10.2.1
+objectidentifier	CertificateList 1.3.6.1.4.1.1466.115.121.1.9
+objectidentifier	AttCertPath 1.3.6.1.4.1.4203.666.11.10.2.4
+objectidentifier	PolicySyntax 1.3.6.1.4.1.4203.666.11.10.2.5
+objectidentifier	RoleSyntax 1.3.6.1.4.1.4203.666.11.10.2.6
+#  NOTE: OIDs from <draft-ietf-pkix-ldap-schema-02.txt> (expired)
+#objectidentifier	AttributeCertificate 1.2.826.0.1.3344810.7.5
+#objectidentifier	AttCertPath 1.2.826.0.1.3344810.7.10
+#objectidentifier	PolicySyntax 1.2.826.0.1.3344810.7.17
+#objectidentifier	RoleSyntax 1.2.826.0.1.3344810.7.13
+##
+## Substitute syntaxes
+##
+## AttCertPath
+ldapsyntax ( 1.3.6.1.4.1.4203.666.11.10.2.4
+	NAME 'AttCertPath'
+	DESC 'X.509 PMI attribute cartificate path: SEQUENCE OF AttributeCertificate'
+	X-SUBST '1.3.6.1.4.1.1466.115.121.1.15' )
+##
+## PolicySyntax
+ldapsyntax ( 1.3.6.1.4.1.4203.666.11.10.2.5
+	NAME 'PolicySyntax'
+	DESC 'X.509 PMI policy syntax'
+	X-SUBST '1.3.6.1.4.1.1466.115.121.1.15' )
+##
+## RoleSyntax
+ldapsyntax ( 1.3.6.1.4.1.4203.666.11.10.2.6
+	NAME 'RoleSyntax'
+	DESC 'X.509 PMI role syntax'
+	X-SUBST '1.3.6.1.4.1.1466.115.121.1.15' )
+##
+## X.509 (08/2005) pp. 71, 86-89
+## 
+## 14.4.1 Role attribute
+attributeType ( id-at-role
+	NAME 'role'
+	DESC 'X.509 Role attribute, use ;binary'
+	SYNTAX RoleSyntax )
+## 
+## 14.5     XML privilege information attribute
+##  -- contains XML-encoded privilege information
+attributeType ( id-at-xMLPrivilegeInfo
+	NAME 'xmlPrivilegeInfo'
+	DESC 'X.509 XML privilege information attribute'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+## 
+## 17.2       PMI Directory attributes
+## 
+## 17.2.1     Attribute certificate attribute
+attributeType ( id-at-attributeCertificate
+	NAME 'attributeCertificateAttribute'
+	DESC 'X.509 Attribute certificate attribute, use ;binary'
+	SYNTAX AttributeCertificate
+	EQUALITY attributeCertificateExactMatch )
+## 
+## 17.2.2     AA certificate attribute
+attributeType ( id-at-aACertificate
+	NAME 'aACertificate'
+	DESC 'X.509 AA certificate attribute, use ;binary'
+	SYNTAX AttributeCertificate
+	EQUALITY attributeCertificateExactMatch )
+## 
+## 17.2.3     Attribute descriptor certificate attribute
+attributeType ( id-at-attributeDescriptorCertificate
+	NAME 'attributeDescriptorCertificate'
+	DESC 'X.509 Attribute descriptor certificate attribute, use ;binary'
+	SYNTAX AttributeCertificate
+	EQUALITY attributeCertificateExactMatch )
+## 
+## 17.2.4     Attribute certificate revocation list attribute
+attributeType ( id-at-attributeCertificateRevocationList
+	NAME 'attributeCertificateRevocationList'
+	DESC 'X.509 Attribute certificate revocation list attribute, use ;binary'
+	SYNTAX CertificateList 
+	X-EQUALITY 'certificateListExactMatch, not implemented yet' )
+## 
+## 17.2.5     AA certificate revocation list attribute
+attributeType ( id-at-attributeAuthorityRevocationList
+	NAME 'attributeAuthorityRevocationList'
+	DESC 'X.509 AA certificate revocation list attribute, use ;binary'
+	SYNTAX CertificateList
+	X-EQUALITY 'certificateListExactMatch, not implemented yet' )
+## 
+## 17.2.6     Delegation path attribute
+attributeType ( id-at-delegationPath
+	NAME 'delegationPath'
+	DESC 'X.509 Delegation path attribute, use ;binary'
+	SYNTAX AttCertPath )
+##     AttCertPath      ::= SEQUENCE OF AttributeCertificate
+## 
+## 17.2.7     Privilege policy attribute
+attributeType ( id-at-privPolicy
+	NAME 'privPolicy'
+	DESC 'X.509 Privilege policy attribute, use ;binary'
+	SYNTAX PolicySyntax )
+## 
+## 17.2.8     Protected privilege policy attribute
+attributeType ( id-at-protPrivPolicy
+	NAME 'protPrivPolicy'
+	DESC 'X.509 Protected privilege policy attribute, use ;binary'
+	SYNTAX AttributeCertificate
+	EQUALITY attributeCertificateExactMatch )
+## 
+## 17.2.9     XML Protected privilege policy attribute
+## -- contains XML-encoded privilege policy information
+attributeType ( id-at-xMLPprotPrivPolicy
+	NAME 'xmlPrivPolicy'
+	DESC 'X.509 XML Protected privilege policy attribute'
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+##
+## 17.1 PMI directory object classes
+## 
+## 17.1.1   PMI user object class
+##    -- a PMI user (i.e., a "holder")
+objectClass ( id-oc-pmiUser
+	NAME 'pmiUser'
+	DESC 'X.509 PMI user object class'
+	SUP top
+	AUXILIARY
+	MAY ( attributeCertificateAttribute ) )
+## 
+## 17.1.2     PMI AA object class
+##     -- a PMI AA
+objectClass ( id-oc-pmiAA
+	NAME 'pmiAA'
+	DESC 'X.509 PMI AA object class'
+	SUP top
+	AUXILIARY
+	MAY ( aACertificate $
+		attributeCertificateRevocationList $
+		attributeAuthorityRevocationList
+	) )
+## 
+## 17.1.3     PMI SOA object class
+##     -- a PMI Source of Authority
+objectClass ( id-oc-pmiSOA
+	NAME 'pmiSOA'
+	DESC 'X.509 PMI SOA object class'
+	SUP top
+	AUXILIARY
+	MAY ( attributeCertificateRevocationList $
+		attributeAuthorityRevocationList $
+		attributeDescriptorCertificate
+	) )
+## 
+## 17.1.4     Attribute certificate CRL distribution point object class
+objectClass ( id-oc-attCertCRLDistributionPts
+	NAME 'attCertCRLDistributionPt'
+	DESC 'X.509 Attribute certificate CRL distribution point object class'
+	SUP top
+	AUXILIARY
+	MAY ( attributeCertificateRevocationList $
+		attributeAuthorityRevocationList
+	) )
+## 
+## 17.1.5     PMI delegation path
+objectClass ( id-oc-pmiDelegationPath
+	NAME 'pmiDelegationPath'
+	DESC 'X.509 PMI delegation path'
+	SUP top
+	AUXILIARY
+	MAY ( delegationPath ) )
+## 
+## 17.1.6     Privilege policy object class
+objectClass ( id-oc-privilegePolicy
+	NAME 'privilegePolicy'
+	DESC 'X.509 Privilege policy object class'
+	SUP top
+	AUXILIARY
+	MAY ( privPolicy ) )
+## 
+## 17.1.7     Protected privilege policy object class
+objectClass ( id-oc-protectedPrivilegePolicy
+	NAME 'protectedPrivilegePolicy'
+	DESC 'X.509 Protected privilege policy object class'
+	SUP top
+	AUXILIARY
+	MAY ( protPrivPolicy ) )
+

--- a/scripts/docker/auth/openldap/schema/ppolicy.schema
+++ b/scripts/docker/auth/openldap/schema/ppolicy.schema
@@ -1,0 +1,531 @@
+# $OpenLDAP$
+## This work is part of OpenLDAP Software <http://www.openldap.org/>.
+##
+## Copyright 2004-2014 The OpenLDAP Foundation.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted only as authorized by the OpenLDAP
+## Public License.
+##
+## A copy of this license is available in the file LICENSE in the
+## top-level directory of the distribution or, alternatively, at
+## <http://www.OpenLDAP.org/license.html>.
+#
+## Portions Copyright (C) The Internet Society (2004).
+## Please see full copyright statement below.
+
+# Definitions from Draft behera-ldap-password-policy-07 (a work in progress)
+#	Password Policy for LDAP Directories
+# With extensions from Hewlett-Packard:
+#	pwdCheckModule etc.
+
+# Contents of this file are subject to change (including deletion)
+# without notice.
+#
+# Not recommended for production use!
+# Use with extreme caution!
+
+#Network Working Group                                     J. Sermersheim
+#Internet-Draft                                               Novell, Inc
+#Expires: April 24, 2005                                        L. Poitou
+#                                                        Sun Microsystems
+#                                                        October 24, 2004
+#
+#
+#                  Password Policy for LDAP Directories
+#                draft-behera-ldap-password-policy-08.txt
+#
+#Status of this Memo
+#
+#   This document is an Internet-Draft and is subject to all provisions
+#   of section 3 of RFC 3667.  By submitting this Internet-Draft, each
+#   author represents that any applicable patent or other IPR claims of
+#   which he or she is aware have been or will be disclosed, and any of
+#   which he or she become aware will be disclosed, in accordance with
+#   RFC 3668.
+#
+#   Internet-Drafts are working documents of the Internet Engineering
+#   Task Force (IETF), its areas, and its working groups.  Note that
+#   other groups may also distribute working documents as
+#   Internet-Drafts.
+#
+#   Internet-Drafts are draft documents valid for a maximum of six months
+#   and may be updated, replaced, or obsoleted by other documents at any
+#   time.  It is inappropriate to use Internet-Drafts as reference
+#   material or to cite them other than as "work in progress."
+#
+#   The list of current Internet-Drafts can be accessed at
+#   http://www.ietf.org/ietf/1id-abstracts.txt.
+#
+#   The list of Internet-Draft Shadow Directories can be accessed at
+#   http://www.ietf.org/shadow.html.
+#
+#   This Internet-Draft will expire on April 24, 2005.
+#
+#Copyright Notice
+#
+#   Copyright (C) The Internet Society (2004).
+#
+#Abstract
+#
+#   Password policy as described in this document is a set of rules that
+#   controls how passwords are used and administered in Lightweight
+#   Directory Access Protocol (LDAP) based directories.  In order to
+#   improve the security of LDAP directories and make it difficult for
+#   password cracking programs to break into directories, it is desirable
+#   to enforce a set of rules on password usage.  These rules are made to
+#
+#  [trimmed]
+#
+#5.  Schema used for Password Policy
+#
+#   The schema elements defined here fall into two general categories.  A
+#   password policy object class is defined which contains a set of
+#   administrative password policy attributes, and a set of operational
+#   attributes are defined that hold general password policy state
+#   information for each user.
+#
+#5.2  Attribute Types used in the pwdPolicy ObjectClass
+#
+#   Following are the attribute types used by the pwdPolicy object class.
+#
+#5.2.1  pwdAttribute
+#
+#   This holds the name of the attribute to which the password policy is
+#   applied.  For example, the password policy may be applied to the
+#   userPassword attribute.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.1
+      NAME 'pwdAttribute'
+      EQUALITY objectIdentifierMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 )
+
+#5.2.2  pwdMinAge
+#
+#   This attribute holds the number of seconds that must elapse between
+#   modifications to the password.  If this attribute is not present, 0
+#   seconds is assumed.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.2
+      NAME 'pwdMinAge'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.3  pwdMaxAge
+#
+#   This attribute holds the number of seconds after which a modified
+#   password will expire.
+#
+#   If this attribute is not present, or if the value is 0 the password
+#   does not expire.  If not 0, the value must be greater than or equal
+#   to the value of the pwdMinAge.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.3
+      NAME 'pwdMaxAge'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.4  pwdInHistory
+#
+#   This attribute specifies the maximum number of used passwords stored
+#   in the pwdHistory attribute.
+#
+#   If this attribute is not present, or if the value is 0, used
+#   passwords are not stored in the pwdHistory attribute and thus may be
+#   reused.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.4
+      NAME 'pwdInHistory'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.5  pwdCheckQuality
+#
+#   {TODO: Consider changing the syntax to OID.  Each OID will list a
+#   quality rule (like min len, # of special characters, etc).  These
+#   rules can be specified outsid ethis document.}
+#
+#   {TODO: Note that even though this is meant to be a check that happens
+#   during password modification, it may also be allowed to happen during
+#   authN.  This is useful for situations where the password is encrypted
+#   when modified, but decrypted when used to authN.}
+#
+#   This attribute indicates how the password quality will be verified
+#   while being modified or added.  If this attribute is not present, or
+#   if the value is '0', quality checking will not be enforced.  A value
+#   of '1' indicates that the server will check the quality, and if the
+#   server is unable to check it (due to a hashed password or other
+#   reasons) it will be accepted.  A value of '2' indicates that the
+#   server will check the quality, and if the server is unable to verify
+#   it, it will return an error refusing the password.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.5
+      NAME 'pwdCheckQuality'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.6  pwdMinLength
+#
+#   When quality checking is enabled, this attribute holds the minimum
+#   number of characters that must be used in a password.  If this
+#   attribute is not present, no minimum password length will be
+#   enforced.  If the server is unable to check the length (due to a
+#   hashed password or otherwise), the server will, depending on the
+#   value of the pwdCheckQuality attribute, either accept the password
+#   without checking it ('0' or '1') or refuse it ('2').
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.6
+      NAME 'pwdMinLength'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.7  pwdExpireWarning
+#
+#   This attribute specifies the maximum number of seconds before a
+#   password is due to expire that expiration warning messages will be
+#   returned to an authenticating user.
+#
+#   If this attribute is not present, or if the value is 0 no warnings
+#   will be returned.  If not 0, the value must be smaller than the value
+#   of the pwdMaxAge attribute.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.7
+      NAME 'pwdExpireWarning'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.8  pwdGraceAuthNLimit
+#
+#   This attribute specifies the number of times an expired password can
+#   be used to authenticate.  If this attribute is not present or if the
+#   value is 0, authentication will fail.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.8
+      NAME 'pwdGraceAuthNLimit'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.9  pwdLockout
+#
+#   This attribute indicates, when its value is "TRUE", that the password
+#   may not be used to authenticate after a specified number of
+#   consecutive failed bind attempts.  The maximum number of consecutive
+#   failed bind attempts is specified in pwdMaxFailure.
+#
+#   If this attribute is not present, or if the value is "FALSE", the
+#   password may be used to authenticate when the number of failed bind
+#   attempts has been reached.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.9
+      NAME 'pwdLockout'
+      EQUALITY booleanMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+      SINGLE-VALUE )
+
+#5.2.10  pwdLockoutDuration
+#
+#   This attribute holds the number of seconds that the password cannot
+#   be used to authenticate due to too many failed bind attempts.  If
+#   this attribute is not present, or if the value is 0 the password
+#   cannot be used to authenticate until reset by a password
+#   administrator.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.10
+      NAME 'pwdLockoutDuration'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.11  pwdMaxFailure
+#
+#   This attribute specifies the number of consecutive failed bind
+#   attempts after which the password may not be used to authenticate.
+#   If this attribute is not present, or if the value is 0, this policy
+#   is not checked, and the value of pwdLockout will be ignored.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.11
+      NAME 'pwdMaxFailure'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.12  pwdFailureCountInterval
+#
+#   This attribute holds the number of seconds after which the password
+#   failures are purged from the failure counter, even though no
+#   successful authentication occurred.
+#
+#   If this attribute is not present, or if its value is 0, the failure
+#   counter is only reset by a successful authentication.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.12
+      NAME 'pwdFailureCountInterval'
+      EQUALITY integerMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+
+#5.2.13  pwdMustChange
+#
+#   This attribute specifies with a value of "TRUE" that users must
+#   change their passwords when they first bind to the directory after a
+#   password is set or reset by a password administrator.  If this
+#   attribute is not present, or if the value is "FALSE", users are not
+#   required to change their password upon binding after the password
+#   administrator sets or resets the password.  This attribute is not set
+#   due to any actions specified by this document, it is typically set by
+#   a password administrator after resetting a user's password.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.13
+      NAME 'pwdMustChange'
+      EQUALITY booleanMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+      SINGLE-VALUE )
+
+#5.2.14  pwdAllowUserChange
+#
+#   This attribute indicates whether users can change their own
+#   passwords, although the change operation is still subject to access
+#   control.  If this attribute is not present, a value of "TRUE" is
+#   assumed.  This attribute is intended to be used in the absense of an
+#   access control mechanism.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.14
+      NAME 'pwdAllowUserChange'
+      EQUALITY booleanMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+      SINGLE-VALUE )
+
+#5.2.15  pwdSafeModify
+#
+#   This attribute specifies whether or not the existing password must be
+#   sent along with the new password when being changed.  If this
+#   attribute is not present, a "FALSE" value is assumed.
+
+attributetype ( 1.3.6.1.4.1.42.2.27.8.1.15
+      NAME 'pwdSafeModify'
+      EQUALITY booleanMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+      SINGLE-VALUE )
+
+# HP extensions
+#
+# pwdCheckModule
+#
+#    This attribute names a user-defined loadable module that provides
+#    a check_password() function. If pwdCheckQuality is set to '1' or '2'
+#    this function will be called after all of the internal password
+#    quality checks have been passed. The function has this prototype:
+#
+#    int check_password( char *password, char **errormessage, void *arg )
+#
+#    The function should return LDAP_SUCCESS for a valid password.
+
+attributetype ( 1.3.6.1.4.1.4754.1.99.1
+     NAME 'pwdCheckModule'
+     EQUALITY caseExactIA5Match
+     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+     DESC 'Loadable module that instantiates "check_password() function'
+     SINGLE-VALUE )
+
+objectclass ( 1.3.6.1.4.1.4754.2.99.1
+      NAME 'pwdPolicyChecker'
+      SUP top
+      AUXILIARY
+      MAY ( pwdCheckModule ) )
+
+#5.1  The pwdPolicy Object Class
+#
+#   This object class contains the attributes defining a password policy
+#   in effect for a set of users.  Section 10 describes the
+#   administration of this object, and the relationship between it and
+#   particular objects.
+#
+objectclass ( 1.3.6.1.4.1.42.2.27.8.2.1
+      NAME 'pwdPolicy'
+      SUP top
+      AUXILIARY
+      MUST ( pwdAttribute )
+      MAY ( pwdMinAge $ pwdMaxAge $ pwdInHistory $ pwdCheckQuality $
+      pwdMinLength $ pwdExpireWarning $ pwdGraceAuthNLimit $ pwdLockout
+      $ pwdLockoutDuration $ pwdMaxFailure $ pwdFailureCountInterval $
+      pwdMustChange $ pwdAllowUserChange $ pwdSafeModify ) )
+
+#5.3  Attribute Types for Password Policy State Information
+#
+#   Password policy state information must be maintained for each user.
+#   The information is located in each user entry as a set of operational
+#   attributes.  These operational attributes are: pwdChangedTime,
+#   pwdAccountLockedTime, pwdFailureTime, pwdHistory, pwdGraceUseTime,
+#   pwdReset, pwdPolicySubEntry.
+#
+#5.3.1  Password Policy State Attribute Option
+#
+#   Since the password policy could apply to several attributes used to
+#   store passwords, each of the above operational attributes must have
+#   an option to specify which pwdAttribute it applies to.  The password
+#   policy option is defined as the following:
+#
+#   pwd-<passwordAttribute>
+#
+#   where passwordAttribute a string following the OID syntax
+#   (1.3.6.1.4.1.1466.115.121.1.38).  The attribute type descriptor
+#   (short name) MUST be used.
+#
+#   For example, if the pwdPolicy object has for pwdAttribute
+#   "userPassword" then the pwdChangedTime operational attribute, in a
+#   user entry, will be:
+#
+#   pwdChangedTime;pwd-userPassword: 20000103121520Z
+#
+#   This attribute option follows sub-typing semantics.  If a client
+#   requests a password policy state attribute to be returned in a search
+#   operation, and does not specify an option, all subtypes of that
+#   policy state attribute are returned.
+#
+#5.3.2  pwdChangedTime
+#
+#   This attribute specifies the last time the entry's password was
+#   changed.  This is used by the password expiration policy.  If this
+#   attribute does not exist, the password will never expire.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.16
+#      NAME 'pwdChangedTime'
+#      DESC 'The time the password was last changed'
+#      EQUALITY generalizedTimeMatch
+#      ORDERING generalizedTimeOrderingMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+#      SINGLE-VALUE
+#      USAGE directoryOperation )
+#
+#5.3.3  pwdAccountLockedTime
+#
+#   This attribute holds the time that the user's account was locked.  A
+#   locked account means that the password may no longer be used to
+#   authenticate.  A 000001010000Z value means that the account has been
+#   locked permanently, and that only a password administrator can unlock
+#   the account.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.17
+#      NAME 'pwdAccountLockedTime'
+#      DESC 'The time an user account was locked'
+#      EQUALITY generalizedTimeMatch
+#      ORDERING generalizedTimeOrderingMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+#      SINGLE-VALUE
+#      USAGE directoryOperation )
+#
+#5.3.4  pwdFailureTime
+#
+#   This attribute holds the timestamps of the consecutive authentication
+#   failures.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.19
+#      NAME 'pwdFailureTime'
+#      DESC 'The timestamps of the last consecutive authentication
+#      failures'
+#      EQUALITY generalizedTimeMatch
+#      ORDERING generalizedTimeOrderingMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+#      USAGE directoryOperation )
+#
+#5.3.5  pwdHistory
+#
+#   This attribute holds a history of previously used passwords.  Values
+#   of this attribute are transmitted in string format as given by the
+#   following ABNF:
+#
+#   pwdHistory = time "#" syntaxOID "#" length "#" data
+#
+#   time       = <generalizedTimeString as specified in 6.14
+#                 of [RFC2252]>
+#
+#   syntaxOID  = numericoid    ; the string representation of the
+#                              ; dotted-decimal OID that defines the
+#                              ; syntax used to store the password.
+#                              ; numericoid is described in 4.1
+#                              ; of [RFC2252].
+#
+#   length     = numericstring ; the number of octets in data.
+#                              ; numericstring is described in 4.1
+#                              ; of [RFC2252].
+#
+#   data       = <octets representing the password in the format
+#                 specified by syntaxOID>.
+#
+#   This format allows the server to store, and transmit a history of
+#   passwords that have been used.  In order for equality matching to
+#   function properly, the time field needs to adhere to a consistent
+#   format.  For this purpose, the time field MUST be in GMT format.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.20
+#      NAME 'pwdHistory'
+#      DESC 'The history of user s passwords'
+#      EQUALITY octetStringMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+#      USAGE directoryOperation )
+#
+#5.3.6  pwdGraceUseTime
+#
+#   This attribute holds the timestamps of grace authentications after a
+#   password has expired.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.21
+#      NAME 'pwdGraceUseTime'
+#      DESC 'The timestamps of the grace authentication after the
+#      password has expired'
+#      EQUALITY generalizedTimeMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+#
+#5.3.7  pwdReset
+#
+#   This attribute holds a flag to indicate (when TRUE) that the password
+#   has been updated by the password administrator and must be changed by
+#   the user on first authentication.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.22
+#      NAME 'pwdReset'
+#      DESC 'The indication that the password has been reset'
+#      EQUALITY booleanMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+#      SINGLE-VALUE
+#      USAGE directoryOperation )
+#
+#5.3.8  pwdPolicySubentry
+#
+#   This attribute points to the pwdPolicy subentry in effect for this
+#   object.
+#
+#      ( 1.3.6.1.4.1.42.2.27.8.1.23
+#      NAME 'pwdPolicySubentry'
+#      DESC 'The pwdPolicy subentry in effect for this object'
+#      EQUALITY distinguishedNameMatch
+#      SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+#      SINGLE-VALUE
+#      USAGE directoryOperation )
+#
+#
+#Disclaimer of Validity
+#
+#   This document and the information contained herein are provided on an
+#   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+#   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+#   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+#   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+#   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+#   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+#
+#
+#Copyright Statement
+#
+#   Copyright (C) The Internet Society (2004).  This document is subject
+#   to the rights, licenses and restrictions contained in BCP 78, and
+#   except as set forth therein, the authors retain all their rights.
+

--- a/scripts/docker/auth/openldap/slapd.conf
+++ b/scripts/docker/auth/openldap/slapd.conf
@@ -1,0 +1,67 @@
+#
+# See slapd.conf(5) for details on configuration options.
+# This file should NOT be world readable.
+#
+
+include		/etc/ldap/schema/microsoftattributetype.schema
+include		/etc/ldap/schema/microsoftattributetypestd.schema
+include		/etc/ldap/schema/corba.schema
+include		/etc/ldap/schema/core.schema
+include		/etc/ldap/schema/cosine.schema
+include		/etc/ldap/schema/duaconf.schema
+include		/etc/ldap/schema/dyngroup.schema
+include		/etc/ldap/schema/inetorgperson.schema
+include		/etc/ldap/schema/java.schema
+include		/etc/ldap/schema/misc.schema
+include		/etc/ldap/schema/nis.schema
+include		/etc/ldap/schema/openldap.schema
+include		/etc/ldap/schema/ppolicy.schema
+include		/etc/ldap/schema/collective.schema
+include		/etc/ldap/schema/microsoftobjectclass.schema
+
+pidfile		/var/run/openldap/slapd.pid
+argsfile	/var/run/openldap/slapd.args
+
+# Load dynamic backend modules
+# - modulepath is architecture dependent value (32/64-bit system)
+# - back_sql.la overlay requires openldap-server-sql package
+# - dyngroup.la and dynlist.la cannot be used at the same time
+
+moduleload accesslog.la
+moduleload auditlog.la
+moduleload back_ldap.la
+moduleload back_mdb.la
+moduleload back_meta.la
+moduleload rwm.la
+moduleload unique.la
+
+# enable on-the-fly configuration (cn=config)
+database config
+access to *
+	by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage
+	by * none
+
+#######################################################################
+# Configuration backend providing config and schema settings
+#######################################################################
+database	config
+rootdn		"cn=config"
+rootpw		config
+
+#######################################################################
+# Database backend containing the LDAP data
+#######################################################################
+database	mdb
+suffix		"dc=dev,dc=domain"
+checkpoint	1024 15
+rootdn		"cn=admin,dc=dev,dc=domain"
+rootpw		admin
+
+directory	/var/lib/ldap
+
+index objectClass                       eq,pres
+index ou,cn,mail,surname,givenname      eq,pres,sub
+index uidNumber,gidNumber,loginShell    eq,pres
+index uid,memberUid                     eq,pres,sub
+index nisMapName,nisMapEntry            eq,pres,sub
+index objectCategory,sAMAccountName     eq,pres,sub

--- a/scripts/provision_auth.rb
+++ b/scripts/provision_auth.rb
@@ -1,0 +1,41 @@
+require_relative 'utilities'
+require 'yaml'
+
+def provision_auth(root_loc)
+  puts colorize_lightblue('Searching for LDIF files in the apps')
+
+  # Load configuration.yml into a Hash
+  config = YAML.load_file("#{root_loc}/dev-env-config/configuration.yml")
+  return unless config['applications']
+
+  started = false
+  config['applications'].each do |appname, _appconfig|
+    # To help enforce the accuracy of the app's dependency file, only search for a conf file
+    # if the app specifically specifies auth in it's commodity list
+    next unless File.exist?("#{root_loc}/apps/#{appname}/configuration.yml")
+    next unless commodity_required?(root_loc, appname, 'auth')
+
+    if commodity_provisioned?(root_loc, appname, 'auth')
+      puts colorize_yellow("LDIF files have already been loaded for #{appname}, skipping")
+    else
+      started = build_auth(root_loc, appname, started)
+
+      # Update the .commodities.yml to indicate that auth has now been provisioned
+      set_commodity_provision_status(root_loc, appname, 'auth', true)
+    end
+  end
+end
+
+def build_auth(root_loc, appname, already_started)
+  # Load any LDIF files contained in the apps into the docker commands list
+  started = already_started
+  Dir.glob("#{root_loc}/apps/#{appname}/fragments/*.ldif").each do |file|
+    puts colorize_pink("Found #{File.basename(file)} in #{appname}")
+    unless started
+      run_command('docker-compose up -d --no-deps openldap')
+      started = true
+    end
+    run_command("docker exec -i openldap ldapadd -D cn=admin,dc=dev,dc=domain -w admin < #{file}")
+  end
+  started
+end

--- a/scripts/vagrant/expose_ports.rb
+++ b/scripts/vagrant/expose_ports.rb
@@ -39,6 +39,8 @@ def get_port_list(root_loc)
 
   add_es_ports(root_loc, port_list)
 
+  add_auth_ports(root_loc, port_list)
+
   # If rabbitmq is being used then expose the rabbitmq admin port
   if commodity?(root_loc, 'rabbitmq')
     port_list.push('35672:5672')
@@ -81,6 +83,12 @@ def add_db_ports(root_loc, port_list)
   port_list.push('15432:5432') if commodity?(root_loc, 'postgres')
 
   port_list.push('15433:5433') if commodity?(root_loc, 'postgres-9.6')
+
+end
+
+def add_auth_ports(root_loc, port_list)
+  port_list.push('1389:1389') if commodity?(root_loc, 'auth') # LDAP
+  port_list.push('8180:8180') if commodity?(root_loc, 'auth') # Keycloak
 end
 
 def add_app_ports(root_loc)

--- a/snippets/ldap-entries.ldif
+++ b/snippets/ldap-entries.ldif
@@ -1,0 +1,48 @@
+version: 1
+
+### Sample entry for a user
+dn: cn=super,dc=dev,dc=domain
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+# The user's login name; must match the cn part of the dn field above
+cn: super
+# First name
+givenName: Super
+# Email name
+mailNickname: super.user
+# Office
+physicalDeliveryOfficeName: Plymouth
+# Surname
+sn: User With All Roles
+# User ID (must be unique)
+uid: 1000
+# SHA-hashed password (= super)
+userPassword:: e1NIQX1oRkc2aWhUWGwxUFRUTE03VWJwR3RMQWw2NEU9
+
+### Another user
+dn: cn=another,dc=dev,dc=domain
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: another
+givenName: Another
+mailNickname: another.user
+physicalDeliveryOfficeName: Coventry
+sn: Other-Surname
+uid: 1001
+# SHA-hashed password (= another)
+userPassword:: e1NIQX10OGovdVB2R2ZCY1RLT0RvOWtOcFRvNWhzelU9
+
+### Sample entry for a group
+dn: cn=my_application_users,dc=dev,dc=domain
+objectClass: groupOfNames
+objectClass: top
+# Group name; must match cn part of dn field above
+cn: my_application_users
+# DNs of member users
+member: cn=super,dc=dev,dc=domain
+member: cn=another,dc=dev,dc=domain
+


### PR DESCRIPTION
Add an `auth` commodity to the common dev env. This commodity adds 2 Docker containers: `openldap` and `keycloak`. OpenLDAP provides LDAP services, whilst Keycloak provides OAuth/OpenID Connect services. This commodity can be used by applications that require authentication without the need to call out to external services such as AD and ADFS.

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
  There are no breaking changes in this pull request.

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [x] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
