### PR TITLE
replace cassandra commodity with postgres-96 commodity

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,8 @@ The list of allowable commodity values is:
 11. wiremock
 12. squid
 13. auth
-14. cassandra
-15. cadence
-16. activemq
+14. cadence
+15. activemq
 
 * The file may optionally also indicate that one or more services are resource intensive ("expensive") when starting up. The dev env will start those containers seperately - 3 at a time - and wait until each are declared healthy (or crash and get restarted 10 times) before starting any more. This requires a healthcheck command specified here or in the Dockerfile/docker-compose-fragment (in which case just use 'docker' in this file).
   * If one of these expensive services prefers another one to be considered "healthy" before a startup attempt is made (such as a database, to ensure immediate connectivity and no expensive restarts) then the dependent service can be specified here, with a healthcheck command following the same rules as above.
@@ -273,20 +272,8 @@ JWT tokens issued from the `development` realm have been configured to mimic tho
 
 A [JSON export](scripts/docker/auth/keycloak/development_realm.json) of the `development` realm is used to configure the realm. If further configuration of the realm is required, you can make changes in the admin console and re-export the realm using the procedure described in "Exporting a realm" [here](https://hub.docker.com/r/jboss/keycloak/#exporting-a-realm). The exported JSON can then be merged back into this repository and reused.
 
-###### Cassandra
-Cassandra is a NoSql database used as persistence layer for Cadence orchestrator.
-
-From within a Docker container:
-
-* Host: cassandra
-* Port: 9042 (CQL Native Transport Port)
-
-From the host system:
-* Host: localhost
-* Port: 9042
-
 ###### Cadence
-Cadence is the Uber-developed HA orchestrator. It's configured to use an auto-setup mode to automatically create cassandra keyspace and tables required for cadence functioning.
+Cadence is the Uber-developed HA orchestrator. It's configured to use an auto-setup mode to automatically create postgres schema and tables required for cadence functioning.
 Use the following configuration to connect your application:
 
 From within a Docker container:

--- a/scripts/docker/cadence/.env_list
+++ b/scripts/docker/cadence/.env_list
@@ -1,2 +1,10 @@
-CASSANDRA_SEEDS=cassandra
+DB=postgres
+DB_PORT=5432
+POSTGRES_USER=root
+POSTGRES_PWD=superroot
+SQL_PLUGIN=postgres
+SQL_USER=root
+SQL_PASSWORD=superroot
+SQL_PORT=5432
+POSTGRES_SEEDS=postgres-96
 DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml

--- a/scripts/docker/cadence/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/cadence/docker-compose-fragment.3.7.yml
@@ -11,4 +11,4 @@ services:
     env_file:
       - ../scripts/docker/cadence/.env_list
     depends_on:
-      - cassandra
+      - postgres-96

--- a/scripts/docker/cadence/docker-compose-fragment.yml
+++ b/scripts/docker/cadence/docker-compose-fragment.yml
@@ -11,4 +11,4 @@ services:
     env_file:
       - ../scripts/docker/cadence/.env_list
     depends_on:
-      - cassandra
+      - postgres-96

--- a/scripts/docker/cassandra/Dockerfile
+++ b/scripts/docker/cassandra/Dockerfile
@@ -1,2 +1,0 @@
-
-FROM cassandra:3.11

--- a/scripts/docker/cassandra/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/cassandra/docker-compose-fragment.3.7.yml
@@ -1,7 +1,0 @@
-version: '3.7'
-services:
-  cassandra:
-    container_name: cassandra
-    build: ../scripts/docker/cassandra/
-    ports:
-      - "9042:9042"

--- a/scripts/docker/cassandra/docker-compose-fragment.yml
+++ b/scripts/docker/cassandra/docker-compose-fragment.yml
@@ -1,7 +1,0 @@
-version: '2'
-services:
-  cassandra:
-    container_name: cassandra
-    build: ../scripts/docker/cassandra/
-    ports:
-      - "9042:9042"


### PR DESCRIPTION
<!-- You can erase any questions or checklists in this template that are not applicable. -->

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Feature update to remove the cassandra commodity and replace with existing postgres-96 commodity

* **What is the current behavior?**
Cassandra currently needed as a commodity required by Cadence

* **What is the new behavior (if this is a feature change)?**
[TAP-3422](https://hmlandregistry.atlassian.net/browse/TAP-3422)

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
No

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [x] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
