### PR TITLE
Change to bashin alias

### DIFF
--- a/scripts/add-aliases.sh
+++ b/scripts/add-aliases.sh
@@ -25,7 +25,13 @@ alias gitpull="bash $DEV_ENV_ROOT_DIR/scripts/git_pull.sh"
 alias cadence-cli="docker run --rm ubercadence/cli:0.7.0 --address host.docker.internal:7933"
 
 function bashin(){
-    docker exec -it ${@:1} bash
+  app_name=${@:1}
+  if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "win"* || "$OSTYPE" == "cygwin"* ]] ; then
+    echo "On a Windows Machine"
+    winpty docker exec -it $app_name bash
+  else
+    docker exec -it $app_name bash
+  fi
 }
 
 function unit-test(){


### PR DESCRIPTION
<!-- You can erase any questions or checklists in this template that are not applicable. -->

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
 Makes the bashin alias change if its being run on a windows machine

* **What is the current behavior?**
 currently when running bashin on a windows machine, an error is presented saying "try prefixing the command with 'winpty'"

* **What is the new behavior (if this is a feature change)?**
  bashin now checks the reported OS

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
  Possibly if $OSTYPE starts reporting something different but the else should catch that and present current behaviour in that scenario. To fix, identify the newly reported value of $OSTYPE and change the if statement as needed

## Checklists

### All submissions

* [X] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [X] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [X] Has your submission been tested locally? On windows 10 and MacOS Big Sur
