### PR TITLE
Created an initial Localstack commodity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ logs/
 .vscode/
 .idea/
 .after-up-once
+node_modules/
+package.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ cadence core services.
 
 A default Localstack configuration is provided with a minimal number of enabled services available (S3 only at present). Localstack does not *require* the use of any other external configuration file (as applications can manage buckets programatically through methods such as the [AWS SDK](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/examples-s3-buckets.html)). However, if additional configuration (such as new buckets) are necessary before application startup, you can use a `localstack-init-fragment.sh` to perform this provisioning; an example of which is provided [here](snippets/localstack-init-fragment.sh). 
 
+Localstack is available at <http://localstack:4566> within the Docker network, and <http://localhost:4566> on the host.
+
 #### Other files
 
 **`/fragments/custom-provision.sh`**

--- a/README.md
+++ b/README.md
@@ -304,6 +304,11 @@ cadence core services.
 *Running Cadence web locally*
 - In a web browser enter http://localhost:5004
 
+###### Localstack
+[Localstack](https://localstack.cloud) is a cloud stack testing and mocking framework for developing against various AWS services.
+
+A default Localstack configuration is provided with a minimal number of enabled services available (S3 only at present). Localstack does not *require* the use of any other external configuration file (as applications can manage buckets programatically through methods such as the [AWS SDK](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/examples-s3-buckets.html)). However, if additional configuration (such as new buckets) are necessary before application startup, you can use a `localstack-init-fragment.sh` to perform this provisioning; an example of which is provided [here](snippets/localstack-init-fragment.sh). 
+
 #### Other files
 
 **`/fragments/custom-provision.sh`**

--- a/scripts/add-aliases.sh
+++ b/scripts/add-aliases.sh
@@ -88,6 +88,10 @@ function manage(){
     ex ${1} python3 manage.py ${@:2}
 }
 
+function localstack(){
+    ex localstack awslocal ${@:1}
+}
+
 function fullreset(){
     stop ${1}
     remove ${1}
@@ -146,5 +150,6 @@ function devenv-help(){
     add-to-docker-compose
       <name of new compose fragment>                 -     looks in fragments folder of loaded apps to search for a new docker-compose-fragment including the provided parameter eg docker-compose-syt2-fragment then runs docker-compose up
     cadence-cli                                      -     runs the command line tool to interact with cadence orchestrator
+    localstack                                       -     run localstack commands in the localstack container
 EOF
 }

--- a/scripts/add-aliases.sh
+++ b/scripts/add-aliases.sh
@@ -150,6 +150,6 @@ function devenv-help(){
     add-to-docker-compose
       <name of new compose fragment>                 -     looks in fragments folder of loaded apps to search for a new docker-compose-fragment including the provided parameter eg docker-compose-syt2-fragment then runs docker-compose up
     cadence-cli                                      -     runs the command line tool to interact with cadence orchestrator
-    localstack                                       -     run localstack commands in the localstack container
+    localstack                                       -     run localstack (aws) commands in the localstack container
 EOF
 }

--- a/scripts/commodities.rb
+++ b/scripts/commodities.rb
@@ -9,6 +9,7 @@ require_relative 'provision_nginx'
 require_relative 'provision_elasticsearch5'
 require_relative 'provision_elasticsearch'
 require_relative 'provision_wiremock'
+require_relative 'provision_localstack'
 
 require 'fileutils'
 require 'open3'
@@ -155,6 +156,8 @@ def provision_commodities(root_loc, new_containers)
   provision_wiremock(root_loc, new_containers)
   # Hosts File
   provision_hosts(root_loc)
+  # Localstack
+  provision_localstack(root_loc, new_containers)
 end
 
 def container_to_commodity(container_name)

--- a/scripts/docker/localstack/.env_list
+++ b/scripts/docker/localstack/.env_list
@@ -1,0 +1,3 @@
+SERVICES=s3
+DEBUG=1
+DATA_DIR=/tmp/localstack/data

--- a/scripts/docker/localstack/Dockerfile
+++ b/scripts/docker/localstack/Dockerfile
@@ -1,0 +1,2 @@
+FROM localstack/localstack:0.14.0
+

--- a/scripts/docker/localstack/compose-fragment.yml
+++ b/scripts/docker/localstack/compose-fragment.yml
@@ -4,5 +4,4 @@ services:
     build: ../scripts/docker/localstack/
     ports:
       - "4566:4566"
-      - "8050:8080"
     env_file: ../scripts/docker/localstack/.env_list

--- a/scripts/docker/localstack/compose-fragment.yml
+++ b/scripts/docker/localstack/compose-fragment.yml
@@ -1,0 +1,8 @@
+services:
+  localstack:
+    container_name: localstack
+    build: ../scripts/docker/localstack/
+    ports:
+      - "4566:4566"
+      - "8050:8080"
+    env_file: ../scripts/docker/localstack/.env_list

--- a/scripts/docker/localstack/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/localstack/docker-compose-fragment.3.7.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  localstack:
+    container_name: localstack
+    build: ../scripts/docker/localstack/
+    ports:
+      - "4566:4566"
+      - "8050:8080"
+    env_file: ../scripts/docker/localstack/.env_list

--- a/scripts/docker/localstack/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/localstack/docker-compose-fragment.3.7.yml
@@ -5,5 +5,4 @@ services:
     build: ../scripts/docker/localstack/
     ports:
       - "4566:4566"
-      - "8050:8080"
     env_file: ../scripts/docker/localstack/.env_list

--- a/scripts/docker/localstack/docker-compose-fragment.yml
+++ b/scripts/docker/localstack/docker-compose-fragment.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  localstack:
+    container_name: localstack
+    build: ../scripts/docker/localstack/
+    ports:
+      - "4566:4566"
+      - "8050:8080"
+    env_file: ../scripts/docker/localstack/.env_list

--- a/scripts/docker/localstack/docker-compose-fragment.yml
+++ b/scripts/docker/localstack/docker-compose-fragment.yml
@@ -5,5 +5,4 @@ services:
     build: ../scripts/docker/localstack/
     ports:
       - "4566:4566"
-      - "8050:8080"
     env_file: ../scripts/docker/localstack/.env_list

--- a/scripts/provision_localstack.rb
+++ b/scripts/provision_localstack.rb
@@ -27,7 +27,7 @@ def provision_localstack(root_loc, new_containers)
 
     # Load any SQL contained in the apps into the docker commands list
     if File.exist?("#{root_loc}/apps/#{appname}/fragments/localstack-init-fragment.sh")
-      database_initialised = process_localstack_fragment(root_loc, appname, localstack_initialised, new_db_container)
+      process_localstack_fragment(root_loc, appname, localstack_initialised, new_db_container)
     else
       puts colorize_yellow("#{appname} says it uses Localstack but doesn't contain an init file.
           Oh well, onwards we go!")

--- a/scripts/provision_localstack.rb
+++ b/scripts/provision_localstack.rb
@@ -62,11 +62,11 @@ def init_localstack_sh(root_loc, appname)
   cmd = 'docker exec localstack bash -c "sh /localstack-init-fragment.sh"'
   exit_code = run_command(cmd)
 
-  puts colorize_lightblue("Completed #{appname} localstack fragment")
+  puts colorize_lightblue("Completed #{appname} Localstack fragment")
 
   if ![0].include?(exit_code)
     # if exit_code != 0
-    puts colorize_red("Something went wrong with the localstack setup. Exitcode - #{exit_code}")
+    puts colorize_red("Something went wrong with the Localstack setup. Exitcode - #{exit_code}")
   else
     puts colorize_yellow("Localstack initialised correctly. Exitcode - #{exit_code}.")
     set_commodity_provision_status(root_loc, appname, 'localstack', true)

--- a/scripts/provision_localstack.rb
+++ b/scripts/provision_localstack.rb
@@ -20,7 +20,7 @@ def provision_localstack(root_loc, new_containers)
   localstack_initialised = false
 
   config['applications'].each do |appname, _appconfig|
-    # To help enforce the accuracy of the app's dependency file, only search for init sql
+    # To help enforce the accuracy of the app's dependency file, only search for init script
     # if the app specifically specifies localstack in it's commodity list
     next unless File.exist?("#{root_loc}/apps/#{appname}/configuration.yml")
     next unless commodity_required?(root_loc, appname, 'localstack')

--- a/scripts/provision_localstack.rb
+++ b/scripts/provision_localstack.rb
@@ -1,0 +1,80 @@
+require_relative 'utilities'
+require_relative 'commodities'
+require 'yaml'
+
+def provision_localstack(root_loc, new_containers)
+  puts colorize_lightblue('Searching for Localstack initialisation script in the apps')
+
+  # Load configuration.yml into a Hash
+  config = YAML.load_file("#{root_loc}/dev-env-config/configuration.yml")
+  return unless config['applications']
+
+  # Did the container previously exist, if not then we MUST provision regardless of .commodities value
+  new_db_container = false
+  if new_containers.include?('localstack')
+    new_db_container = true
+    puts colorize_yellow('The Localstack container has been newly created - '\
+                         'provision status in .commodities will be ignored')
+  end
+
+  localstack_initialised = false
+
+  config['applications'].each do |appname, _appconfig|
+    # To help enforce the accuracy of the app's dependency file, only search for init sql
+    # if the app specifically specifies localstack in it's commodity list
+    next unless File.exist?("#{root_loc}/apps/#{appname}/configuration.yml")
+    next unless commodity_required?(root_loc, appname, 'localstack')
+
+    # Load any SQL contained in the apps into the docker commands list
+    if File.exist?("#{root_loc}/apps/#{appname}/fragments/localstack-init-fragment.sh")
+      database_initialised = process_localstack_fragment(root_loc, appname, localstack_initialised, new_db_container)
+    else
+      puts colorize_yellow("#{appname} says it uses Localstack but doesn't contain an init file.
+          Oh well, onwards we go!")
+    end
+  end
+end
+
+def process_localstack_fragment(root_loc, appname, localstack_initialised, new_db_container)
+  result = localstack_initialised
+  puts colorize_pink("Found some in #{appname}")
+  if commodity_provisioned?(root_loc, appname, 'localstack') && !new_db_container
+    puts colorize_yellow("Localstack has previously been provisioned for #{appname}, skipping")
+  else
+    unless localstack_initialised
+      init_localstack
+      result = true
+    end
+    init_localstack_sh(root_loc, appname)
+  end
+  result
+end
+
+def init_localstack_sh(root_loc, appname)
+  # See comments in provision_postgres.rb for why we are doing it this way
+  run_command('tar -c' \
+              " -C #{root_loc}/apps/#{appname}/fragments" \
+              ' localstack-init-fragment.sh' \
+              ' | docker cp - localstack:/')
+
+  run_command('docker exec localstack bash -c "chmod o+rx /localstack-init-fragment.sh"')
+
+  cmd = 'docker exec localstack bash -c "sh /localstack-init-fragment.sh"'
+  exit_code = run_command(cmd)
+
+  puts colorize_lightblue("Completed #{appname} localstack fragment")
+
+  if ![0].include?(exit_code)
+    # if exit_code != 0
+    puts colorize_red("Something went wrong with the localstack setup. Exitcode - #{exit_code}")
+  else
+    puts colorize_yellow("Localstack initialised correctly. Exitcode - #{exit_code}.")
+    set_commodity_provision_status(root_loc, appname, 'localstack', true)
+  end
+end
+
+def init_localstack
+  # Start Localstack
+  run_command("#{ENV['DC_CMD']} up -d localstack")
+  puts colorize_green('Localstack is ready')
+end

--- a/scripts/remove-aliases.sh
+++ b/scripts/remove-aliases.sh
@@ -27,6 +27,7 @@ unset -f acclint
 unset -f manage
 unset -f fullreset
 unset -f alembic
+unset -f localstack
 unset -f add-to-docker-compose
 unset -f devenv-help
 

--- a/snippets/localstack-init-fragment.sh
+++ b/snippets/localstack-init-fragment.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This is an example custom-provision script that creates a new S3 bucket in localstack (if it doesn't already exist),
+# wipes the contents of said bucket, and enables versioning on said bucket.
+# Each command will be run sequentially in the container.
+awslocal s3 mb s3://example-bucket
+awslocal s3 rm s3://example-bucket --recursive
+awslocal s3api put-bucket-versioning --bucket example-bucket --versioning-configuration Status=Enabled

--- a/snippets/localstack-init-fragment.sh
+++ b/snippets/localstack-init-fragment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This is an example custom-provision script that creates a new S3 bucket in localstack (if it doesn't already exist),
+# This is an example fragment that creates a new S3 bucket in localstack (if it doesn't already exist),
 # wipes the contents of said bucket, and enables versioning on said bucket.
 # Each command will be run sequentially in the container.
 awslocal s3 mb s3://example-bucket


### PR DESCRIPTION
<!-- You can erase any questions or checklists in this template that are not applicable. -->

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
  Feature

* **What is the current behavior?**
  Applications are currently provisioning their own Localstack instances on a per-app basis, leading to duplication of code

* **What is the new behavior (if this is a feature change)?**
  Adding a basic Localstack commodity to the common dev-env for use by all applications that require a Localstack instance to test S3 connections against.

  Additionally, adding the new alias `localstack` to run `aws` commands directly against the container without having to bashin to the container and run them from there (similar to how the `manage` command allows you to skip that step). Note: I have aliased this to `awslocal ${@:1}` in the container (this is the same as `aws` but negating the need for the `--endpoint-url` parameter - commands run in the same way, however).

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
  No; new commodity only

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [x] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
