### PR TITLE
Hotfix - Cope with standalone Docker

### DIFF
--- a/logic.rb
+++ b/logic.rb
@@ -76,7 +76,7 @@ end.parse!
 
 # Does a version check and self-update if required
 if options['self_update']
-  this_version = '1.21.0'
+  this_version = '1.21.1'
   puts colorize_lightblue("This is a universal dev env (version #{this_version})")
   # Skip version check if not on master (prevents infinite loops if you're in a branch that isn't up to date with the
   # latest release code yet)

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,16 @@
 export DC_VERSION=1
-docker-compose version 2>&1 | grep -q 'version 2\|version v2' && DC_VERSION=2 && echo -e "\e[35mUsing Docker-Compose version 2 commands\e[0m"
+
+# No docker-compose command means v2 is implied
+docker-compose > /dev/null 2>&1
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  DC_VERSION=2
+else
+  docker-compose version 2>&1 | grep -q 'version 2\|version v2' && DC_VERSION=2
+fi
 
 if [ "$DC_VERSION" = "2" ] ; then
+  echo -e "\e[35mUsing Docker-Compose version 2 commands\e[0m"
   export DC_CMD='docker compose'
 else
   export DC_CMD='docker-compose --compatibility'


### PR DESCRIPTION
Where you access Compose via `docker compose` only, and `docker-compose` does not exist
