### PR TITLE
Firebird/multi wiremock

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ This is a file that contains stub mappings that Wiremock will pick up and use, a
 
 [Example](snippets/wiremock-fragment.json)
 
+**`/fragments/wiremock/`**
+
+This is a directory that can contain multiple stub mappings files that Wiremock will pick up and use. The files should all be in the same format as the example above. If such a wiremock directory exists, it will take precedence over any `wiremock-fragment.json` file.
+
 ##### RabbitMQ
 
 There are no fragments needed when using this. The Management Console will be available on <http://localhost:15672> (guest/guest).


### PR DESCRIPTION
Files added/updated:

- `scripts/provision_wiremock.rb` updated with support for a wiremock directory inside the fragments folder (instead of the usual single `wiremock-fragment.json` file)

 __What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?__

Feature

__What is the current behaviour?__

All wiremock mappings must be placed in a single file called `wiremock-fragment.json`. This can become cumbersome to work with as projects grow.

__What is the new behavior (if this is a feature change)?__

Allows for using multiple wiremock files instead of one. Wiremock files located within the wiremock directory will be combined together (the directory takes precedence over a single `wiremock-fragment.json`). This provides readability and convenience for developers.

__Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?__

No, existing repositories that use just one `wiremock-fragment.json` file are still supported.

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [x] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
