### PR TITLE
Updated all Dockerfiles and docker-compose files to use full tag name, and update to official Apache ActiveMQ classic image

### DIFF
--- a/scripts/docker/activemq/Dockerfile
+++ b/scripts/docker/activemq/Dockerfile
@@ -1,2 +1,2 @@
 # This is so a reset (dc down) won't remove the base AMQ image, only the one created from this dockerfile
-FROM rmohr/activemq:5.15.9
+FROM docker.io/apache/activemq-classic:5.18.2

--- a/scripts/docker/auth/keycloak/Dockerfile
+++ b/scripts/docker/auth/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:7.0.0
+FROM docker.io/jboss/keycloak:7.0.0
 
 ADD development_realm.json /etc/keycloak/
 

--- a/scripts/docker/auth/openldap/Dockerfile
+++ b/scripts/docker/auth/openldap/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM docker.io/debian:10
 
 # For some reason some people get hash mismatch issues. This tries to resolve that.
 # See https://askubuntu.com/questions/1121093/hash-sum-mismatches-in-18-04-on-laptop-and-in-docker

--- a/scripts/docker/cadence-web/Dockerfile
+++ b/scripts/docker/cadence-web/Dockerfile
@@ -1,2 +1,2 @@
 
-FROM ubercadence/web:3.18.1
+FROM docker.io/ubercadence/web:3.18.1

--- a/scripts/docker/cadence/Dockerfile
+++ b/scripts/docker/cadence/Dockerfile
@@ -1,2 +1,2 @@
 
-FROM ubercadence/server:0.14.1-auto-setup
+FROM docker.io/ubercadence/server:0.14.1-auto-setup

--- a/scripts/docker/db2_community/Dockerfile
+++ b/scripts/docker/db2_community/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmlandregistry/db2-cgroupaware:11.5.8.0
+FROM docker.io/hmlandregistry/db2-cgroupaware:11.5.8.0
 
 EXPOSE 50000 55000
 

--- a/scripts/docker/elasticsearch5/Dockerfile
+++ b/scripts/docker/elasticsearch5/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:5.2.1
+FROM docker.io/elasticsearch:5.2.1
 
 ENV ES_JAVA_OPTS -Xms1024m -Xmx1024m
 

--- a/scripts/docker/localstack/Dockerfile
+++ b/scripts/docker/localstack/Dockerfile
@@ -1,1 +1,1 @@
-FROM localstack/localstack:2.2
+FROM docker.io/localstack/localstack:2.2

--- a/scripts/docker/logging/Dockerfile
+++ b/scripts/docker/logging/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim
+FROM docker.io/python:3.11.3-slim
 
 ENV PYTHONUNBUFFERED yes
 COPY tini server.py run.sh /

--- a/scripts/docker/nginx/Dockerfile
+++ b/scripts/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.22
+FROM docker.io/nginx:1.22
 
 RUN apt-get update && apt-get install openssl && \
   rm /etc/nginx/conf.d/default.conf && \

--- a/scripts/docker/postgres-13/Dockerfile
+++ b/scripts/docker/postgres-13/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13
+FROM docker.io/postgres:13
 
 # For some reason some people get hash mismatch issues. This tries to resolve that.
 # See https://askubuntu.com/questions/1121093/hash-sum-mismatches-in-18-04-on-laptop-and-in-docker

--- a/scripts/docker/rabbitmq/Dockerfile
+++ b/scripts/docker/rabbitmq/Dockerfile
@@ -1,5 +1,5 @@
 # This is so a reset (dc down) won't remove the base rabbit image, only the one created from this dockerfile
-FROM rabbitmq:3-management
+FROM docker.io/rabbitmq:3-management
 # Copy the configuration file to rabbitmq
 # https://www.rabbitmq.com/configure.html#configuration-files
 COPY rabbitmq.conf /etc/rabbitmq/

--- a/scripts/docker/redis/Dockerfile
+++ b/scripts/docker/redis/Dockerfile
@@ -1,2 +1,2 @@
 # This is so a reset (dc down) won't remove the base redis image, only the one created from this dockerfile
-FROM redis:7.0
+FROM docker.io/redis:7.0

--- a/scripts/docker/squid/Dockerfile
+++ b/scripts/docker/squid/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmlandregistry/squid:6
+FROM docker.io/hmlandregistry/squid:6
 # We have this as a Dockerfile rather than just specifying the image in the
 # compose fragment, to prevent it being deleted in a destroy, so it doesn't
 # need to be redownloaded

--- a/scripts/docker/swagger/compose-fragment.yml
+++ b/scripts/docker/swagger/compose-fragment.yml
@@ -1,7 +1,7 @@
 services:
   swagger:
     container_name: swagger
-    image: swaggerapi/swagger-ui
+    image: docker.io/swaggerapi/swagger-ui
     ports:
       - 5101:8080
     platform: "linux/amd64"

--- a/scripts/docker/swagger/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/swagger/docker-compose-fragment.3.7.yml
@@ -2,6 +2,6 @@ version: '3.7'
 services:
   swagger:
     container_name: swagger
-    image: swaggerapi/swagger-ui
+    image: docker.io/swaggerapi/swagger-ui
     ports:
       - 5101:8080

--- a/scripts/docker/swagger/docker-compose-fragment.yml
+++ b/scripts/docker/swagger/docker-compose-fragment.yml
@@ -2,6 +2,6 @@ version: '2'
 services:
   swagger:
     container_name: swagger
-    image: swaggerapi/swagger-ui
+    image: docker.io/swaggerapi/swagger-ui
     ports:
       - 5101:8080

--- a/scripts/docker/wiremock/Dockerfile
+++ b/scripts/docker/wiremock/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM docker.io/openjdk:11-jre-slim
 
 ARG WM_VERSION=2.32.0
 


### PR DESCRIPTION
* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Feature

* **What is the current behavior?**
Dockerfile's are referencing base images by their "short tag name", which defaults to Dockerhub as the registry image pulls. This is fine when using Docker as the container framework, but causes incompatibility with other OCI-compliant container frameworks (such as Podman).

Also, the ActiveMQ Classic image currently being referenced in the devenv is provided by a third-party.

* **What is the new behavior (if this is a feature change)?**
To improve compatibility with other non-docker OCI compliant container frameworks that do not default to the Dockerhub registry, this change is to add the registry to all Dockerfiles and docker-compose files that pull images.

In addition, the ActiveMQ Classic image has been changed to use the official Apache-provided image.

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
No; images will continue to pull from the same location, and the new ActiveMQ Classic image is fully backwards-compatible.

## Checklists

### All submissions

* [/ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [/ ] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [/ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [/ ] Has your submission been tested locally?
* [/ ] Has documentation such as the [README](/README.md) been updated if necessary?
* [/ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
