### PR TITLE
Add 'aliases' command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -101,6 +101,11 @@ then
     source scripts/docker_prepare.sh &&
     source scripts/add-aliases.sh
 
+elif [ "$command" = "aliases" ]
+then
+    source scripts/docker_prepare.sh &&
+    source scripts/add-aliases.sh
+
 else
     echo "Syntax:
    source run.sh [command] [flags]
@@ -118,6 +123,7 @@ else
                     images and (optionally) reset common-dev-env configuration
       repair        set the docker-compose configuration to use *this* dev-env,
                     for users with several common-dev-env instances
+      aliases       import aliases only; useful if you use multiple shells
 
    flags:
       -n, --nopull  for 'up' and 'reload' only; avoid docker hub ratelimiting 


### PR DESCRIPTION
This command allows sourcing only the helper aliases useful for interacting with the common-dev-env. This may be useful if you use multiple shell sessions and already have the CDE running.

<!-- You can erase any questions or checklists in this template that are not applicable. -->

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
  New feature command

* **What is the current behavior?**
I generally just `source run.sh quickup` in the new shell, but that does a bunch of stuff that isn't strictly needed.

* **What is the new behavior (if this is a feature change)?**
A new command `aliases` that only injects the helper aliases (and dependent env vars) into the shell session. Unfortunately it's not quite as simple as directly sourcing `add-aliases.sh` because there are some dependencies between various files (eg `add-aliases.sh` expects some env vars from `docker_prepare.sh`). Best to keep that wrapped up inside common-dev-env's context.

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
No.

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [ ] Has documentation such as the [README](/README.md) been updated if necessary?
* [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
