### PR TITLE
Added ulimits to Squid proxy docker compose fragments

### DIFF
--- a/scripts/docker/squid/compose-fragment.yml
+++ b/scripts/docker/squid/compose-fragment.yml
@@ -5,3 +5,7 @@ services:
     ports:
       - 30128:3128
     platform: "linux/amd64"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536

--- a/scripts/docker/squid/docker-compose-fragment.3.7.yml
+++ b/scripts/docker/squid/docker-compose-fragment.3.7.yml
@@ -5,3 +5,7 @@ services:
     build: ../scripts/docker/squid/
     ports:
       - 30128:3128
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536

--- a/scripts/docker/squid/docker-compose-fragment.yml
+++ b/scripts/docker/squid/docker-compose-fragment.yml
@@ -5,3 +5,7 @@ services:
     build: ../scripts/docker/squid/
     ports:
       - 30128:3128
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536


### PR DESCRIPTION
* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Bugfix

* **What is the current behavior?**
Squid proxy container attempts to open with 2^30 file descriptors on RHEL/Fedora-based hosts; causing a container crash.

Issue does not affect Ubuntu hosts

* **What is the new behavior (if this is a feature change)?**
Limit file descriptors to 65536, preventing crashing.

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
No; change is backwards compatible

## Checklists

### All submissions

* [ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [ ] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [ ] Has your submission been tested locally?
* [ ] Has documentation such as the [README](/README.md) been updated if necessary?
* [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
