### PR TITLE
Enable linting for Ruby and Markdown files with super-linter and Github Actions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        # The only difference between full and slim is the latter contains .NET and Rust linters
+        # The only difference between full and slim is the latter excludes .NET and Rust linters
       - uses: super-linter/super-linter/slim@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,9 +19,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: super-linter/super-linter/lite@v6
+        # The only difference between full and slim is the latter contains .NET and Rust linters
+      - uses: super-linter/super-linter/slim@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Only run against
+          # Only run against ruby and markdown - we don't care about the others
           VALIDATE_RUBY: true
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,6 +24,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Only run against ruby and markdown - we don't care about the others
-          RUBY_CONFIG_FILE: .rubocop.yml
+          RUBY_CONFIG_FILE: ${{ github.workspace }}/.rubocop.yml
           VALIDATE_RUBY: true
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: super-linter/super-linter/lite@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Only run against
+          VALIDATE_RUBY: true
+          VALIDATE_MARKDOWN: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: super-linter/super-linter/slim@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: .
           # Only run against ruby and markdown - we don't care about the others
-          RUBY_CONFIG_FILE: ${{ github.workspace }}/.rubocop.yml
+          RUBY_CONFIG_FILE: .rubocop.yml
           VALIDATE_RUBY: true
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,5 +24,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Only run against ruby and markdown - we don't care about the others
+          RUBY_CONFIG_FILE: .rubocop.yml
           VALIDATE_RUBY: true
           VALIDATE_MARKDOWN: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
 
   Exclude:
     - 'apps/**/*'
+    - 'scripts/docker/**/*'
 
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
<!-- You can erase any questions or checklists in this template that are not applicable. -->

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Feature

* **What is the current behavior?**
Linting checks are currently the responsibility of the PR creator. This has created a number of linting issues with the markdown and ruby source files in the repo as time has progressed.

* **What is the new behavior (if this is a feature change)?**
Implemented GitHub actions against PRs, as well as against the develop and master branches of the repo.

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
No, although PR submitters will start to see linting information more readily against their PRs

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [ ] Has documentation such as the [README](/README.md) been updated if necessary?
* [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
