### PR TITLE
Update Keycloak Base Image

### DIFF
--- a/scripts/docker/auth/keycloak/Dockerfile
+++ b/scripts/docker/auth/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/jboss/keycloak:7.0.0
+FROM quay.io/keycloak/keycloak:7.0.1
 
 ADD development_realm.json /etc/keycloak/
 


### PR DESCRIPTION
older keycloak images have been removed from docker.io. Replace with latest 7.x image from quay.io as these seem to be the official images, and still have the older images available. Long term, we should probably update the keycloak version here but that needs more work

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Bug fix

* **What is the current behavior?**
build of environment fails due to missing image

* **What is the new behavior (if this is a feature change)?**
environment builds successfully

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
no breaking changes

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [n/a] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
