### PR TITLE
Updates to Wiremock - only rename file that exists, and update Wiremo…

### DIFF
--- a/scripts/docker/wiremock/Dockerfile
+++ b/scripts/docker/wiremock/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/openjdk:11-jre-slim
+FROM docker.io/eclipse-temurin:21-jre-ubi9-minimal
 
-ARG WM_VERSION=2.32.0
+ARG WM_VERSION=3.6.0
 
-RUN apt-get update && apt-get -y install curl && mkdir -p /wiremock/mappings && cd /wiremock && \
-  curl -sSL -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WM_VERSION/wiremock-jre8-standalone-$WM_VERSION.jar
+RUN mkdir -p /wiremock/mappings && cd /wiremock && \
+    curl -sSL -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/$WM_VERSION/wiremock-standalone-$WM_VERSION.jar
 
 WORKDIR /wiremock
 

--- a/scripts/provision_wiremock.rb
+++ b/scripts/provision_wiremock.rb
@@ -57,11 +57,13 @@ def build_wiremock(root_loc, appname, already_started, new_container)
                     ' | docker cp - wiremock:/wiremock/mappings/')
       end
 
-      # Rename the file so it is unique and wont get overwritten by any others we copy up
-      # Also, GitBash needs the inner quotes to be doubles
-      run_command('docker exec wiremock bash -c "' \
-        "mv /wiremock/mappings/wiremock-fragment.json /wiremock/mappings/#{appname}-wiremock-fragment.json" \
-        '"')
+      if wiremock_file
+        # Rename the file so it is unique and wont get overwritten by any others we copy up
+        # Also, GitBash needs the inner quotes to be doubles
+        run_command('docker exec wiremock bash -c "' \
+            "mv /wiremock/mappings/wiremock-fragment.json /wiremock/mappings/#{appname}-wiremock-fragment.json" \
+            '"')
+      end
 
       # Update the .commodities.yml to indicate that Wiremock has now been provisioned
       set_commodity_provision_status(root_loc, appname, 'wiremock', true)


### PR DESCRIPTION
<!-- You can erase any questions or checklists in this template that are not applicable. -->

* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
  Commodity update and bug fix

* **What is the current behavior?**
  Wiremock is very out of date.
  A wiremock commodity with a folder of WM configuration fails to provision with "mv: cannot stat '/wiremock/mappings/wiremock-fragment.json': No such file or directory"

* **What is the new behavior (if this is a feature change)?**
  Wiremock is up to date
  Doesn't fall over when provisioning with a folder of WM config and no wiremock-fragment.json

* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
  Possible with the WM upgrade but was unable to test as none of my wiremock configuration worked at all with 2.x

## Checklists

### All submissions

* [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [x] Has your submission been tested locally?
* [x] Has documentation such as the [README](/README.md) been updated if necessary?
* [x] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
