### PR TITLE
Fix #166 update keycloak avoiding deprecated docker image format

### DIFF
--- a/scripts/docker/auth/keycloak/Dockerfile
+++ b/scripts/docker/auth/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:7.0.1
+FROM quay.io/keycloak/keycloak:9.0.3
 
 ADD development_realm.json /etc/keycloak/
 


### PR DESCRIPTION
* **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Bug fix for #166 updates keycloak from `7.0.1` to `9.0.3` to use a release with a non-deprecated image format.

* **What is the current behavior?**
If you have a recent docker installation you cannot pull and start the keycloak image and container with the command `source run.sh up` because the image format used by that container has deprecated.

* **What is the new behavior (if this is a feature change)?**
If you have a recent docker you can now pull and start the keycloak container with the above command.


* **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
The fix here updates the keycloak container to use keycloak `9.0.3` which works with our tests in AP.  As the PR updates the version from `7.0.1` to `9.0.3` there is a possibility that this change may break other capabilities.

Newer versions of keycloak than this require both additional changes in configuration and changes in behaviour due to how keycloak responds to unknown scopes.

## Checklists

### All submissions

* [X] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
* [X] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

* [X] Has your submission been tested locally?