### PR TITLE
Correcting version string for cadence-web

### DIFF
--- a/scripts/docker/cadence-web/Dockerfile
+++ b/scripts/docker/cadence-web/Dockerfile
@@ -1,2 +1,2 @@
 
-FROM docker.io/ubercadence/web:3.35.6
+FROM docker.io/ubercadence/web:v3.35.6


### PR DESCRIPTION
Since v3.20.0, cadence web version strings include a v
Attempting to pull "docker.io/ubercadence/web:3.35.6" fails, works correctly with the v
<!-- You can erase any questions or checklists in this template that are not applicable. -->

- **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
  _answer_

- **What is the current behavior?**
  _answer (You can also just link to an open issue here)_

- **What is the new behavior (if this is a feature change)?**
  _answer_

- **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
  _answer_

## Checklists

### All submissions

- [ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

- [ ] Has your submission been tested locally?
- [ ] Has documentation such as the [README](/README.md) been updated if necessary?
- [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
