### PR TITLE
Update alembic alias to work with Python 3.13

### DIFF
--- a/scripts/add-aliases.sh
+++ b/scripts/add-aliases.sh
@@ -165,7 +165,8 @@ function fullreset(){
 
 function alembic(){
     ex -e SQL_USE_ALEMBIC_USER=yes -e SQL_PASSWORD=superroot -e SQLALCHEMY_POOL_RECYCLE=3600 ${1} \
-        bash -c 'cd /src && python3 manage.py db '"${@:2}"''
+        bash -c '( cd /src 2>/dev/null && python3 manage.py db '"${@:2}"' ) || \
+        ( cd /opt/app-root/src && /opt/app-root/venv/bin/flask db '"${@:2}"' )'
 }
 
 function devenv-help(){

--- a/scripts/add-aliases.sh
+++ b/scripts/add-aliases.sh
@@ -164,9 +164,11 @@ function fullreset(){
 }
 
 function alembic(){
+    # If Python 3.13, use flask command. Otherwise, use manage.py
     ex -e SQL_USE_ALEMBIC_USER=yes -e SQL_PASSWORD=superroot -e SQLALCHEMY_POOL_RECYCLE=3600 ${1} \
-        bash -c '( cd /src 2>/dev/null && python3 manage.py db '"${@:2}"' ) || \
-        ( cd /opt/app-root/src && /opt/app-root/venv/bin/flask db '"${@:2}"' )'
+      bash -c 'cd /opt/app-root/src && if [[ "$PYTHON_VERSION" == "3.13" ]];
+      then /opt/app-root/venv/bin/flask db '"${@:2}"'
+      else python3 manage.py db '"${@:2}"'; fi'
 }
 
 function devenv-help(){


### PR DESCRIPTION

- **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Feature

- **What is the current behaviour?**
With the new Python 3.13 updates, the alembic() alias no longer works. The command cannot find "/src", which has now been replaced with "/opt/app-root/src", and it uses "python3", which no longer works with Python 3.13.

- **What is the new behaviour (if this is a feature change)?**
  This merge request is to make the alembic() alias work for applications using 3.13. It keeps the current solution for backwards compatibility - If the current command doesn't work, it tries the 3.13 command. The new command uses "/opt/app-root/src" instead of "/src" and replaces manage.py with a flask command.  
  
- **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
 No

## Checklists

### All submissions

- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New feature and bug fix submissions

- [x] Has your submission been tested locally?
- [ ] Has documentation such as the [README](/README.md) been updated if necessary?
- [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
