### PR TITLE
added prometheus and grafana docker files and fragments. enabled prometheus metric plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The list of allowable commodity values is:
 16. ibmmq
 17. localstack
 18. valkey
+19. prometheus
+20. grafana
 
 The file may optionally also indicate that one or more services are resource intensive ("expensive") when starting up. The dev env will start those containers seperately - 3 at a time - and wait until each are declared healthy (or crash and get restarted 10 times) before starting any more.
 
@@ -228,7 +230,7 @@ TLS presents a self signed cert. If verification is needed then use the provided
 
 MTLS is not enabled, although a [client certificate pem](scripts/docker/rabbitmq/certs/client_certificate.pem) and [client key pem](scripts/docker/rabbitmq/certs/client_key.pem) have been generated as part of the certificate set for potential future use.
 
-Currently, only the `rabbitmq_management`, `rabbitmq_consistent_hash_exchange`, `rabbitmq_shovel`, `rabbitmq_shovel_management` and `rabbitmq_stream` plugins are enabled.
+Currently, only the `rabbitmq_management`, `rabbitmq_consistent_hash_exchange`, `rabbitmq_shovel`, `rabbitmq_shovel_management`, `rabbitmq_stream` and `rabbitmq_prometheus` plugins are enabled.
 
 ##### ActiveMQ
 
@@ -248,6 +250,15 @@ You can monitor Redis activity using the CLI:
 bashin redis
 redis-cli monitor
 ```
+
+##### Prometheus
+
+Prometheus will be available at <http://localhost:9090>. The scrape config lives in `dev-env-config/prometheus/prometheus.yml` and is mounted by any app that needs Prometheus.
+For production, avoid high-cardinality RabbitMQ metrics unless needed. Prefer to keep only specific queues with `metric_relabel_configs`, or disable per-queue metrics at the broker if you only need aggregate health.
+
+##### Grafana
+
+Grafana will be available at <http://localhost:3000> (admin/admin). Provisioning is defined in `dev-env-config/grafana/provisioning/`. Dashboards live inside each app at `apps/<app>/fragments/grafana/dashboards/` and are mounted into Grafana by the app’s compose fragment.
 
 ##### Squid
 

--- a/scripts/docker/grafana/Dockerfile
+++ b/scripts/docker/grafana/Dockerfile
@@ -1,0 +1,1 @@
+FROM grafana/grafana-oss:latest

--- a/scripts/docker/grafana/Dockerfile
+++ b/scripts/docker/grafana/Dockerfile
@@ -1,1 +1,1 @@
-FROM grafana/grafana-oss:latest
+FROM grafana/grafana-oss:12.3.3

--- a/scripts/docker/grafana/compose-fragment.yml
+++ b/scripts/docker/grafana/compose-fragment.yml
@@ -1,0 +1,8 @@
+services:
+  grafana:
+    container_name: grafana
+    build: ../scripts/docker/grafana/
+    ports:
+      - 3000:3000
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin

--- a/scripts/docker/prometheus/Dockerfile
+++ b/scripts/docker/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:latest
+COPY prometheus.yml /etc/prometheus/prometheus.yml

--- a/scripts/docker/prometheus/Dockerfile
+++ b/scripts/docker/prometheus/Dockerfile
@@ -1,2 +1,2 @@
-FROM prom/prometheus:latest
+FROM prom/prometheus:v3.9.1
 COPY prometheus.yml /etc/prometheus/prometheus.yml

--- a/scripts/docker/prometheus/compose-fragment.yml
+++ b/scripts/docker/prometheus/compose-fragment.yml
@@ -1,0 +1,6 @@
+services:
+  prometheus:
+    container_name: prometheus
+    build: ../scripts/docker/prometheus/
+    ports:
+      - 9090:9090

--- a/scripts/docker/prometheus/prometheus.yml
+++ b/scripts/docker/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]

--- a/scripts/docker/rabbitmq/Dockerfile
+++ b/scripts/docker/rabbitmq/Dockerfile
@@ -17,3 +17,5 @@ RUN rabbitmq-plugins --offline enable rabbitmq_shovel rabbitmq_shovel_management
 # Streams are a new persistent and replicated data structure, handy to persist historic messages for a period of time
 # https://www.rabbitmq.com/stream.html
 RUN rabbitmq-plugins --offline enable rabbitmq_stream
+# Expose Prometheus metrics for monitoring/dashboards.
+RUN rabbitmq-plugins --offline enable rabbitmq_prometheus

--- a/scripts/docker/rabbitmq/Dockerfile
+++ b/scripts/docker/rabbitmq/Dockerfile
@@ -16,6 +16,6 @@ RUN rabbitmq-plugins --offline enable rabbitmq_shovel rabbitmq_shovel_management
 # This is a RabbitMQ plugin that exposes streams. 
 # Streams are a new persistent and replicated data structure, handy to persist historic messages for a period of time
 # https://www.rabbitmq.com/stream.html
-RUN rabbitmq-plugins --offline enable rabbitmq_stream
 # Expose Prometheus metrics for monitoring/dashboards.
-RUN rabbitmq-plugins --offline enable rabbitmq_prometheus
+RUN rabbitmq-plugins --offline enable rabbitmq_stream && \
+    rabbitmq-plugins --offline enable rabbitmq_prometheus

--- a/scripts/docker/rabbitmq/compose-fragment.yml
+++ b/scripts/docker/rabbitmq/compose-fragment.yml
@@ -4,5 +4,11 @@ services:
     build: ../scripts/docker/rabbitmq/
     ports:
       - 15672:15672
+      - 15692:15692
       - 5672:5672
       - 5671:5671
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/scripts/docker/rabbitmq/compose-fragment.yml
+++ b/scripts/docker/rabbitmq/compose-fragment.yml
@@ -7,8 +7,9 @@ services:
       - 15692:15692
       - 5672:5672
       - 5671:5671
+    # Lightweight TCP check on AMQP port (RabbitMQ recommend this over rabbitmq-diagnostics ping).
     healthcheck:
-      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/5672' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/scripts/docker/rabbitmq/rabbitmq.conf
+++ b/scripts/docker/rabbitmq/rabbitmq.conf
@@ -5,3 +5,6 @@ ssl_options.certfile   = /certs/server_certificate.pem
 ssl_options.keyfile    = /certs/server_key.pem
 ssl_options.verify = verify_none
 ssl_options.fail_if_no_peer_cert = false
+
+# Enable per-queue metrics for dashboards.
+prometheus.return_per_object_metrics = true


### PR DESCRIPTION

- **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**

>  Feature. It adds Prometheus and Grafana as new commodities and enables the RabbitMQ Prometheus plugin (plus RabbitMQ healthcheck and per-queue metrics).


- **What is the new behavior (if this is a feature change)?**

> - Prometheus and Grafana are new commodities (options 19 and 20 in configuration.yml). When enabled, Prometheus is at     http://localhost:9090 with scrape config in dev-env-config/prometheus/prometheus.yml; Grafana is at http://localhost:3000 (admin/admin) with provisioning under dev-env-config/grafana/provisioning/ and app dashboards under apps/<app>/fragments/grafana/dashboards/.

> - RabbitMQ: the rabbitmq_prometheus plugin is enabled, metrics are exposed on port 15692, per-queue metrics are enabled via prometheus.return_per_object_metrics = true, and a healthcheck is added so RabbitMQ can be used reliably in composed startup.

- **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**

> No. Changes are additive: new commodities (opt-in) and extra RabbitMQ plugin/port/healthcheck. Existing configs and apps keep working. No actions are required to “regain compatibility.”

## Checklists

### All submissions

- [✓] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [✓] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
- [✓] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

- [✓] Has your submission been tested locally?
- [✓] Has documentation such as the [README](/README.md) been updated if necessary?
- [ ] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
