### PR TITLE
Modify alembic function for virtual environment support

### DIFF
--- a/scripts/add-aliases.sh
+++ b/scripts/add-aliases.sh
@@ -165,7 +165,8 @@ function fullreset(){
 
 function alembic(){
     ex -e SQL_USE_ALEMBIC_USER=yes -e SQL_PASSWORD=superroot -e SQLALCHEMY_POOL_RECYCLE=3600 ${1} \
-        bash -c 'cd /src && python3 manage.py db '"${@:2}"''
+        bash -c 'cd /opt/app-root/src && [ -d "$VENV_DIR" ] && source $VENV_DIR/bin/activate;
+        python3 manage.py db '"${@:2}"''
 }
 
 function devenv-help(){


### PR DESCRIPTION
Source venv if env var is defined to allow support for newer images (e.g. python 3.13)
Something of a duplicate of https://github.com/LandRegistry/common-dev-env/pull/182 since Sarah is off sick currently and we're hitting this issue with our new APIs.

<!-- You can erase any questions or checklists in this template that are not applicable. -->

- **What kind of change does this PR introduce (Bug fix, feature, docs update, ...)?**
Source venv if env var is defined to allow support for newer images (e.g. python 3.13)

- **What is the current behavior?**
Alembic alias does not work with newer base images, e.g. python 3.13

- **What is the new behavior (if this is a feature change)?**
Fixes existing feature

- **Does this PR introduce a breaking change? If so, what actions will users need to take in order to regain compatibility?**
No

## Checklists

### All submissions

- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [x] Is this PR targeting the `develop` branch, and the branch rebased with commits squashed if needed?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase the following part of this template if it's not applicable to your Pull Request. -->

### New feature and bug fix submissions

- [x] Has your submission been tested locally?
- [n/a] Has documentation such as the [README](/README.md) been updated if necessary?
- [n/a is in bash script] Have you linted your new code (using rubocop and markdownlint), and are not introducing any new offenses?
